### PR TITLE
feat(gitutils): ✨ add rebase composite action (pure shell)

### DIFF
--- a/.github/actions/rebase/action.yml
+++ b/.github/actions/rebase/action.yml
@@ -1,0 +1,32 @@
+# @format
+
+name: Rebase PR
+description: Rebase a pull request branch onto its base using pure shell + git CLI
+
+inputs:
+  autosquash:
+    description: Apply autosquash (squash!/fixup! commits)
+    required: false
+    default: 'false'
+  token:
+    description: GitHub token with repo write access
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Configure git identity
+      shell: sh
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+
+    - name: Rebase branch onto base
+      shell: sh
+      env:
+        AUTOSQUASH: ${{ inputs.autosquash }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: ${{ github.action_path }}/rebase.sh

--- a/.github/actions/rebase/rebase.sh
+++ b/.github/actions/rebase/rebase.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# Rebase the current PR branch onto its base branch.
+# Inspired by https://github.com/cirrus-actions/rebase
+# Uses only sh + standard git + gh CLI — no external action dependencies.
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# Resolve pull-request metadata via gh CLI
+# ---------------------------------------------------------------------------
+pr_number=$(gh pr view --json number --jq '.number' 2>/dev/null || true)
+
+if [ -z "$pr_number" ]; then
+    echo "::error::Could not resolve the pull request number from the current context."
+    exit 1
+fi
+
+head_ref=$(gh pr view "$pr_number" --json headRefName --jq '.headRefName')
+base_ref=$(gh pr view "$pr_number" --json baseRefName --jq '.baseRefName')
+head_repo=$(gh pr view "$pr_number" --json headRepositoryOwner,headRepository --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
+
+echo "::group::Rebase PR #${pr_number}: ${head_ref} → ${base_ref}"
+echo "Head repo : $head_repo"
+echo "Head ref  : $head_ref"
+echo "Base ref  : $base_ref"
+echo "Autosquash: ${AUTOSQUASH:-false}"
+
+# ---------------------------------------------------------------------------
+# Configure the remote for the head fork (supports cross-fork PRs)
+# ---------------------------------------------------------------------------
+current_remote=$(git remote get-url origin 2>/dev/null || true)
+head_url="https://x-access-token:${GH_TOKEN}@github.com/${head_repo}.git"
+
+if git remote | grep -q '^head_fork$'; then
+    git remote set-url head_fork "$head_url"
+else
+    git remote add head_fork "$head_url"
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch both branches with full history
+# ---------------------------------------------------------------------------
+git fetch --no-tags origin "${base_ref}:refs/remotes/origin/${base_ref}" 2>&1 | sed 's/^/[fetch] /'
+git fetch --no-tags head_fork "${head_ref}:refs/remotes/head_fork/${head_ref}" 2>&1 | sed 's/^/[fetch] /'
+
+# ---------------------------------------------------------------------------
+# Check whether rebase is actually needed
+# ---------------------------------------------------------------------------
+base_sha=$(git rev-parse "refs/remotes/origin/${base_ref}")
+head_sha=$(git rev-parse "refs/remotes/head_fork/${head_ref}")
+merge_base=$(git merge-base "$base_sha" "$head_sha")
+
+if [ "$merge_base" = "$base_sha" ]; then
+    echo "::notice::Branch is already up-to-date with ${base_ref} — nothing to do."
+    echo "::endgroup::"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Perform the rebase on a detached worktree
+# ---------------------------------------------------------------------------
+git checkout --detach "refs/remotes/head_fork/${head_ref}"
+
+autosquash_flag=""
+if [ "${AUTOSQUASH:-false}" = "true" ]; then
+    autosquash_flag="--autosquash"
+fi
+
+GIT_SEQUENCE_EDITOR=true \
+    git rebase \
+        --interactive \
+        $autosquash_flag \
+        --autostash \
+        "refs/remotes/origin/${base_ref}"
+
+# ---------------------------------------------------------------------------
+# Push the rebased history back (force-with-lease for safety)
+# ---------------------------------------------------------------------------
+git push head_fork "HEAD:refs/heads/${head_ref}" --force-with-lease="${head_ref}:${head_sha}"
+
+echo "::notice::Successfully rebased ${head_ref} onto ${base_ref}."
+echo "::endgroup::"

--- a/.github/skills/feature-gitutils/SKILL.md
+++ b/.github/skills/feature-gitutils/SKILL.md
@@ -18,6 +18,38 @@ Use this feature for advanced Git operations, interactive repository maintenance
 - `git release-hotfix` - Start a Git Flow hotfix branch.
 - `git release-prod` - Finish release/hotfix flow for production.
 - `git unset <prefix> [--local|--global|--system]` - Remove git config keys by prefix.
+- `git autorebase [-f] [-p] [-a] [-n] [-s strategy] [-o onto] [-b branch] [sha]` - Non-interactive rebase with automatic conflict resolution.
+
+## GitHub Actions
+
+### `.github/actions/rebase`
+
+A self-contained composite action that rebases a pull request branch onto its base.
+Implemented in pure `sh` + `git` + `gh` CLI — no external action dependencies.
+
+**Inputs:**
+
+| Input | Default | Description |
+|---|---|---|
+| `autosquash` | `false` | Apply `--autosquash` (squash!/fixup! commits) |
+| `token` | `github.token` | GitHub token with repo write access |
+
+**Trigger:** Called from `.github/workflows/rebase-pr.yml` when a PR comment contains `/rebase` or `/autosquash`.
+
+**To reuse in another workflow:**
+```yaml
+- uses: ./.github/actions/rebase
+  with:
+    autosquash: 'true'
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+**Key behaviours:**
+- Resolves PR metadata (head/base branches, fork URL) via `gh pr view`.
+- Skips if the branch is already up-to-date (no unnecessary force-push).
+- Supports cross-fork PRs by adding a temporary `head_fork` remote.
+- Uses `--force-with-lease` to avoid clobbering concurrent pushes.
+- Respects `--autosquash` when `fixup!`/`squash!` commits are present.
 
 ## Use For
 
@@ -25,6 +57,7 @@ Use this feature for advanced Git operations, interactive repository maintenance
 - Commit cleanup/fixup workflows.
 - Release branch shortcuts (`beta`, `hfix`, `prod`).
 - Batch repository operations and helper aliases.
+- Automated PR rebasing via GitHub Actions comment triggers.
 
 ## Do Not Use For
 
@@ -36,3 +69,5 @@ Use this feature for advanced Git operations, interactive repository maintenance
 - Prefer built-in aliases/utilities before crafting raw multi-step Git commands.
 - For history-rewrite actions, use explicit/force flags only when requested.
 - Keep operations scoped and reversible where possible.
+- When creating GitHub Actions that perform rebases, use `.github/actions/rebase` instead of third-party actions.
+- The composite action shell script (`rebase.sh`) follows the same `sh` conventions as the other scripts in this feature — POSIX-compatible, `set -eu`, `gh` CLI for GitHub API calls.

--- a/.github/workflows/rebase-pr.yml
+++ b/.github/workflows/rebase-pr.yml
@@ -16,13 +16,13 @@ jobs:
       )
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
-      - name: Automatic Rebase
-        uses: cirrus-actions/rebase@1.8
+          fetch-depth: 0
+
+      - name: Rebase PR
+        uses: ./.github/actions/rebase
         with:
           autosquash: ${{ contains(github.event.comment.body, '/autosquash') || contains(github.event.comment.body, '/rebase-autosquash') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Replaces the `cirrus-actions/rebase@1.8` third-party dependency with a **self-contained composite action** implemented in pure `sh` + `git` + `gh` CLI — consistent with the existing coding style across the `gitutils` feature.

## Changes

### New: `.github/actions/rebase/`
- **`action.yml`** — Composite action definition with `autosquash` and `token` inputs
- **`rebase.sh`** — Pure shell rebase script inspired by cirrus-actions/rebase:
  - Resolves PR metadata (head/base refs, fork URL) via `gh pr view`
  - Supports cross-fork PRs via a temporary `head_fork` remote
  - Skips if branch is already up-to-date (no unnecessary force-push)
  - Uses `--force-with-lease` for safe push
  - Supports `--autosquash` flag
  - POSIX `sh` with `set -eu`, no external dependencies

### Updated: `.github/workflows/rebase-pr.yml`
- Switched from `cirrus-actions/rebase@1.8` → `uses: ./.github/actions/rebase`
- Bumped `actions/checkout` from `v3` → `v4`

### Updated: `.github/skills/feature-gitutils/SKILL.md`
- Added documentation for the new composite action
- Added agent guidance: prefer `.github/actions/rebase` over third-party actions
- Added `git autorebase` command to the commands list

## Testing

Comment `/rebase` or `/autosquash` on any open PR to trigger the workflow.

## References

- Inspired by https://github.com/cirrus-actions/rebase
