### PR TITLE
feat: add gemini code assist stubs with conventional commit styleguide (#41)

### DIFF
--- a/stubs/.gemini/config.yaml
+++ b/stubs/.gemini/config.yaml
@@ -1,0 +1,24 @@
+# .gemini/config.yaml
+# Gemini Code Assist configuration for this repository.
+# Reference: https://developers.google.com/gemini-code-assist/docs/customize-repo-review
+
+have_fun: false
+
+memory_config:
+  disabled: false
+
+code_review:
+  disable: false
+  # Surface ALL comments including LOW severity to maximise code-change proposals
+  comment_severity_threshold: LOW
+  # No cap on review comments — let Gemini propose as many changes as needed
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true          # Post a PR summary automatically on open
+    code_review: true      # Trigger full code review on every PR open
+    include_drafts: true   # Also review draft PRs to get early feedback
+  pull_request_synchronized:
+    summary: false         # Skip re-summary on force-push/new commits
+    code_review: true      # Re-run full review on every new push
+    include_drafts: true

--- a/stubs/.gemini/config.yaml
+++ b/stubs/.gemini/config.yaml
@@ -1,24 +1,23 @@
+# @format
+
 # .gemini/config.yaml
 # Gemini Code Assist configuration for this repository.
 # Reference: https://developers.google.com/gemini-code-assist/docs/customize-repo-review
 
-have_fun: false
-
 memory_config:
-  disabled: false
+    enabled: false
 
 code_review:
-  disable: false
-  # Surface ALL comments including LOW severity to maximise code-change proposals
-  comment_severity_threshold: LOW
-  # No cap on review comments — let Gemini propose as many changes as needed
-  max_review_comments: -1
-  pull_request_opened:
-    help: false
-    summary: true          # Post a PR summary automatically on open
-    code_review: true      # Trigger full code review on every PR open
-    include_drafts: true   # Also review draft PRs to get early feedback
-  pull_request_synchronized:
-    summary: false         # Skip re-summary on force-push/new commits
-    code_review: true      # Re-run full review on every new push
-    include_drafts: true
+    enabled: true
+    # Surface ALL comments including LOW severity to maximise code-change proposals
+    comment_severity_threshold: INFO
+    # No cap on review comments — let Gemini propose as many changes as needed
+    max_review_comments: 30
+    pull_request_opened:
+        help: false
+        summary: true # Post a PR summary automatically on open
+        code_review: true # Trigger full code review on every PR open
+        include_drafts: true # Also review draft PRs to get early feedback
+    pull_request_synchronized:
+        summary: false # Skip re-summary on force-push/new commits
+        include_drafts: true

--- a/stubs/.gemini/styleguide.md
+++ b/stubs/.gemini/styleguide.md
@@ -1,0 +1,64 @@
+# Repository Style Guide
+
+## Reviewer Behaviour
+
+**Always propose concrete code changes.** For every issue, smell, or improvement identified
+during a review, Gemini must provide an actionable code suggestion using GitHub's
+suggestion block syntax:
+
+~~~suggestion
+// corrected code here
+~~~
+
+Observations without an accompanying code suggestion are not sufficient.
+When a fix is non-trivial or spans multiple files, provide the corrected snippet
+for each affected location and explain the rationale inline.
+
+## Commit Messages
+
+All commit suggestions **must** follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+
+### Format
+
+```
+<type>(<optional scope>): <short description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Allowed Types
+
+| Type       | When to use                                      |
+|------------|--------------------------------------------------|
+| `feat`     | A new feature                                    |
+| `fix`      | A bug fix                                        |
+| `docs`     | Documentation-only changes                       |
+| `style`    | Formatting, whitespace (no logic change)         |
+| `refactor` | Code restructure without feature/fix             |
+| `perf`     | Performance improvement                          |
+| `test`     | Adding or updating tests                         |
+| `chore`    | Build process, dependencies, tooling             |
+| `ci`       | CI/CD configuration changes                      |
+| `revert`   | Reverts a previous commit                        |
+
+### Rules
+
+- The **type** is mandatory and must be lowercase.
+- The **description** must be in the imperative mood, lowercase, must **not** end with a period.
+  - ✅ `fix(auth): handle expired token gracefully`
+  - ❌ `Fixed the auth bug.`
+- Breaking changes must append `!` after the type/scope and include a `BREAKING CHANGE:` footer.
+  - Example: `feat!: drop support for Node 14`
+- **Every** code suggestion that would result in a commit must include a Conventional Commit-compliant
+  commit message proposal in the review comment.
+
+## Code Style
+
+- Prefer clarity over cleverness.
+- Keep functions small and single-purpose.
+- Document public APIs and non-obvious logic.
+- Prefer early returns over deeply nested conditionals.
+- Flag any code that could be simplified, extracted, or made more idiomatic — and always
+  provide the simplified version as a suggestion block.

--- a/stubs/.gemini/styleguide.md
+++ b/stubs/.gemini/styleguide.md
@@ -1,3 +1,5 @@
+<!-- @format -->
+
 # Repository Style Guide
 
 ## Reviewer Behaviour
@@ -6,9 +8,9 @@
 during a review, Gemini must provide an actionable code suggestion using GitHub's
 suggestion block syntax:
 
-~~~suggestion
+```suggestion
 // corrected code here
-~~~
+```
 
 Observations without an accompanying code suggestion are not sufficient.
 When a fix is non-trivial or spans multiple files, provide the corrected snippet
@@ -16,41 +18,49 @@ for each affected location and explain the rationale inline.
 
 ## Commit Messages
 
-All commit suggestions **must** follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+All commit suggestions **must** follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification with [devmoji](https://github.com/folke/devmoji#default-devmoji-reference). This ensures a consistent commit history and enables automated changelog generation.
 
 ### Format
 
 ```
-<type>(<optional scope>): <short description>
+<type>[optional scope]: <devmoji icon> <description>
 
 [optional body]
 
 [optional footer(s)]
 ```
 
+#### Scope
+
+Scope should be sub-package or module name that can be deducted from the code changes and pointing to a sub package or module (eg: npm workspaces, composer local packages). If the change is not specific to a sub-package or module, the scope can be omitted.
+
+#### Breaking Changes
+
+A breaking change is any change that would require consumers to modify their code when updating to the new version. In such cases, the commit message must include a `!` after the type/scope and a `BREAKING CHANGE:` footer describing the change and its impact.
+
 ### Allowed Types
 
-| Type       | When to use                                      |
-|------------|--------------------------------------------------|
-| `feat`     | A new feature                                    |
-| `fix`      | A bug fix                                        |
-| `docs`     | Documentation-only changes                       |
-| `style`    | Formatting, whitespace (no logic change)         |
-| `refactor` | Code restructure without feature/fix             |
-| `perf`     | Performance improvement                          |
-| `test`     | Adding or updating tests                         |
-| `chore`    | Build process, dependencies, tooling             |
-| `ci`       | CI/CD configuration changes                      |
-| `revert`   | Reverts a previous commit                        |
+| Type       | When to use                              |
+| ---------- | ---------------------------------------- |
+| `feat`     | A new feature                            |
+| `fix`      | A bug fix                                |
+| `docs`     | Documentation-only changes               |
+| `style`    | Formatting, whitespace (no logic change) |
+| `refactor` | Code restructure without feature/fix     |
+| `perf`     | Performance improvement                  |
+| `test`     | Adding or updating tests                 |
+| `chore`    | Build process, dependencies, tooling     |
+| `ci`       | CI/CD configuration changes              |
+| `revert`   | Reverts a previous commit                |
 
 ### Rules
 
 - The **type** is mandatory and must be lowercase.
 - The **description** must be in the imperative mood, lowercase, must **not** end with a period.
-  - ✅ `fix(auth): handle expired token gracefully`
-  - ❌ `Fixed the auth bug.`
+    - ✅ `fix(auth): handle expired token gracefully`
+    - ❌ `Fixed the auth bug.`
 - Breaking changes must append `!` after the type/scope and include a `BREAKING CHANGE:` footer.
-  - Example: `feat!: drop support for Node 14`
+    - Example: `feat!: drop support for Node 14`
 - **Every** code suggestion that would result in a commit must include a Conventional Commit-compliant
   commit message proposal in the review comment.
 


### PR DESCRIPTION
## What

Adds two stub files under `stubs/.gemini/`:
- **`config.yaml`** — structured Gemini Code Assist configuration with:
  - `comment_severity_threshold: LOW` to surface all possible code-change proposals
  - `max_review_comments: -1` (no cap)
  - Full review triggered on every PR open **and** every new push
  - Draft PRs included to get early feedback
- **`styleguide.md`** — natural-language style guide instructing Gemini to:
  - **Always emit a `suggestion` block** for every issue found (no observation-only comments)
  - Always propose Conventional Commit-compliant commit messages alongside code suggestions

## Why

Closes #41.

Without these stubs, Gemini Code Assist has no project-level instructions and defaults to generic, often observation-only review comments that neither enforce Conventional Commits nor propose concrete code changes.

## How

Option B — `.gemini/` structured stubs per the [official Gemini Code Assist customization guide](https://developers.google.com/gemini-code-assist/docs/customize-repo-review).

## Checklist

- [x] Code follows project conventions
- [x] No tests required (config/doc stubs only)
- [x] No breaking changes
- [x] Ready for review