### PR TITLE
fix(gitutils): fix broken commands, harden release flow, dash portability

### DIFF
--- a/src/common-utils/_zz_prompt.sh
+++ b/src/common-utils/_zz_prompt.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# _zz_prompt.sh — interactive free-form input.
+# Usage: value=$(zz_prompt "Question?" [default])
+# The prompt is written to stderr so stdout carries only the entered value
+# (or the default when the user just presses Enter). POSIX read (dash-safe).
+
+# Source colors script
+. zz_colors
+
+prompt=$1
+default=$2
+
+if [ -n "$default" ]; then
+    printf '%b' "${BBlue}#${None} $prompt ${BBlue}[$default]${None} " >&2
+else
+    printf '%b' "${BBlue}#${None} $prompt " >&2
+fi
+
+read -r value
+[ -z "$value" ] && value=$default
+printf '%s\n' "$value"

--- a/src/common-utils/package.json
+++ b/src/common-utils/package.json
@@ -24,7 +24,8 @@
         "zz-input": "./_zz_input.sh",
         "zz-json": "./_zz_json.sh",
         "zz-log": "./_zz_log.sh",
-        "zz-persist": "./_zz_persist.sh"
+        "zz-persist": "./_zz_persist.sh",
+        "zz-prompt": "./_zz_prompt.sh"
     },
     "scripts": {
         "install": "if [ \"$INIT_CWD\" = \"$PWD\" ]; then sh ./install.sh; fi",

--- a/src/gitutils/README.md
+++ b/src/gitutils/README.md
@@ -8,7 +8,7 @@ This feature provides a set of utilities for working with Git repositories.
 
 ```json
 "features": {
-    "ghcr.io/tomgrv/devcontainer-features/gitutils:5": {}
+    "ghcr.io/tomgrv/devcontainer-features/gitutils:7": {}
 }
 ```
 
@@ -62,21 +62,19 @@ These shortcuts work in conjunction with the `gitversion` utility to automatical
 
 The feature includes the following interactive utilities:
 
-- `git fixup` - Amend the specified commit with current changes and rebase
 - `git align` - Align the current branch with its remote counterpart.
 - `git degit <repository> [directory]` - Download and extract a repository from GitHub, GitLab, or Bitbucket.
 - `git fix date [options] [<commit>]` - Fix commit dates and times in git history. Options include rescheduling commits on specific days of week outside certain time ranges.
 - `git fix blanks [-d]` - Discard tracked text-file changes when differences are only blanks and quote/slash swaps.
 - `git fix message -m <message> [--force|<commit>]` - Rewrite the commit message of a specific commit.
-- `git fixup [--force|<commit>]` - Amend the specified commit with current changes and rebase.
+- `git fix up [--force|<commit>]` - Amend the specified commit with current changes and rebase (alias: `git fu`).
 - `git forall <command>` - Execute a command for all files in the repository.
 - `git getcommit [--force|<commit>]` - Get the commit to fixup.
 - `git integrate` - Integrate modifications from the remote repository.
-- `git movetags` - Move tags to the nearest commit with the same message in the current branch.
 - `git release-beta` - Start a new release branch using Git Flow.
 - `git release-hotfix` - Start a new hotfix branch using Git Flow.
 - `git release-prod` - Finish a release or hotfix branch using Git Flow.
-- `git setrights` - Set permissions for files and directories according to best practices.
+- `git fix rights` - Set permissions for files and directories according to best practices.
 - `git unset <prefix> [--local|--global|--system]` - Unset all Git config keys starting with the given prefix.
 
 ## Aliases
@@ -89,9 +87,6 @@ The following aliases are provided to enhance your Git workflow:
 - `git co <message>` - Commit with the provided message.
 - `git conflict` - List files with merge conflicts.
 - `git continue` - Continue the rebase process after resolving conflicts.
-- `git crush` - Stash all changes, reset to the upstream branch, and apply the stash.
-- `git edit` - Amend the last commit and edit the commit message.
-- `git fixMode` - Apply the reverse diff of the current changes.
 - `git fixable` - List commits that can be fixed up.
 - `git forceable` - List commits that can be force-pushed.
 - `git go <message>` - Commit all changes with the provided message.
@@ -105,7 +100,6 @@ The following aliases are provided to enhance your Git workflow:
 - `git isRebase` - Check if a rebase is in progress.
 - `git pn` - Push without running pre-push hooks.
 - `git prod` - Finish a release or hotfix branch using Git Flow.
-- `git recallId <key>` - Set the Git user name and email to the author of the last commit.
 - `git renameTag <old> <new>` - Rename a tag.
 - `git stack` - Amend the last commit without changing the commit message.
 - `git sync` - Fetch and merge changes from the upstream branch.

--- a/src/gitutils/_git-align.sh
+++ b/src/gitutils/_git-align.sh
@@ -7,7 +7,12 @@ branch=$(git rev-parse --abbrev-ref HEAD)
 origin=$(git config --get branch.$branch.remote)
 
 # Stash all changes, including untracked files, with a message
+# Record the stash ref before/after so we only pop when something was stashed
+# (a clean tree stashes nothing, and an unconditional pop would consume an
+# unrelated, older stash entry).
+before=$(git rev-parse -q --verify refs/stash 2>/dev/null)
 git stash push -u -m "Stashing changes before aligning branch"
+after=$(git rev-parse -q --verify refs/stash 2>/dev/null)
 
 # Fetch the latest changes from the remote and align the branch
 git fetch $origin
@@ -18,8 +23,8 @@ else
     zz_log e "Failed to checkout branch $branch from $origin/$branch"
     git branch -m $branch-to-delete $branch
 fi
-# Apply the stashed changes
-git stash pop
+# Apply the stashed changes only if a new stash entry was created
+[ "$before" != "$after" ] && git stash pop
 
 # Print the current branch name
 zz_log i "Current branch: $(git rev-parse --abbrev-ref HEAD)"

--- a/src/gitutils/_git-fix-base.sh
+++ b/src/gitutils/_git-fix-base.sh
@@ -7,7 +7,7 @@ eval $(
 		    n -      dry-run   show what would be done without making changes
 		    - target target    target branch to rebase commits onto
 		    - source source    source branch to take commits from (default: current branch)
-	help
+help
 )
 
 # Navigate to the repository root

--- a/src/gitutils/_git-fix-base.sh
+++ b/src/gitutils/_git-fix-base.sh
@@ -118,14 +118,14 @@ fi
 
 # Cherry-pick commits from source
 zz_log i "Cherry-picking commits..."
+# NB: iterate in the current shell (not a `... | while` subshell) so a failure
+# propagates and we bail out before the destructive reset of the source branch.
 failed=0
-echo "$commits" | while read commit; do
-	if [ -n "$commit" ]; then
-		if ! git cherry-pick "$commit" --strategy=recursive -X theirs --allow-empty; then
-			zz_log e "Cherry-pick failed on commit $commit"
-			failed=1
-			break
-		fi
+for commit in $commits; do
+	if ! git cherry-pick "$commit" --strategy=recursive -X theirs --allow-empty; then
+		zz_log e "Cherry-pick failed on commit $commit"
+		failed=1
+		break
 	fi
 done
 

--- a/src/gitutils/_git-fix-children.sh
+++ b/src/gitutils/_git-fix-children.sh
@@ -6,6 +6,7 @@ set -e
 eval $(
     zz_args "Delete all descendant tags and branches of a commit" $0 "$@" <<-help
 		p -      push       push to remote
+        f -      force      allow overwriting pushed history
 		- sha    sha        sha commit to start from
 	help
 )
@@ -14,7 +15,7 @@ eval $(
 cd "$(git rev-parse --show-toplevel)" >/dev/null
 
 # Retrieve the commit SHA to fixup
-sha=$(git getcommit $sha)
+sha=$(git getcommit $force $sha)
 
 zz_log i "Deleting all tags that are descendants of $sha"
 

--- a/src/gitutils/_git-fix-children.sh
+++ b/src/gitutils/_git-fix-children.sh
@@ -14,7 +14,7 @@ eval $(
 cd "$(git rev-parse --show-toplevel)" >/dev/null
 
 # Retrieve the commit SHA to fixup
-sha=$(git getcommit $force $sha)
+sha=$(git getcommit $sha)
 
 zz_log i "Deleting all tags that are descendants of $sha"
 

--- a/src/gitutils/_git-fix-lock.sh
+++ b/src/gitutils/_git-fix-lock.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 
-# Go to root directory
-cd "$(git rev-parse --show-toplevel)"
+# Function to print help and manage arguments
+eval $(
+	zz_args "Fix git lock files - resolve conflicts and regenerate lock files" $0 "$@" <<-help
+help
+)
+
+# Navigate to the repository root
+cd "$(git rev-parse --show-toplevel)" >/dev/null
 
 # List files with conflicts and filter only lock files
 conflicted_files=$(git diff --name-only --diff-filter=U | grep -E 'composer.lock|package-lock.json|yarn.lock')

--- a/src/gitutils/_git-fix-lock.sh
+++ b/src/gitutils/_git-fix-lock.sh
@@ -9,7 +9,7 @@ conflicted_files=$(git diff --name-only --diff-filter=U | grep -E 'composer.lock
 # Process each lock file with conflicts
 for file in $conflicted_files; do
 
-    # Keep incoming changes by checking out the "ours" version of the file
+    # Keep our version of the lock file, then regenerate it below
     zz_log i "Fixing merge conflict in $file"
     git checkout --ours "$file"
 

--- a/src/gitutils/_git-fix-message.sh
+++ b/src/gitutils/_git-fix-message.sh
@@ -45,7 +45,7 @@ fi
 
 # Ask for the new message if not provided as argument
 if [ -z "$msg" ]; then
-	read -p "New commit message: " msg
+	msg=$(zz_prompt "New commit message:")
 fi
 
 # Ensure message is not empty

--- a/src/gitutils/_git-fix-rights.sh
+++ b/src/gitutils/_git-fix-rights.sh
@@ -1,8 +1,14 @@
 #!/bin/sh
 
-#### GOTO DIRECTORY
-root="$(git rev-parse --show-toplevel)"
-cd "$root" || exit 1
+# Function to print help and manage arguments
+eval $(
+	zz_args "Fix git access rights - set appropriate permissions for files and directories" $0 "$@" <<-help
+
+	help
+)
+
+# Navigate to the repository root
+cd "$(git rev-parse --show-toplevel)" >/dev/null
 
 # Apply the given permission to the tracked files matching the given pathspecs.
 # Operates on files tracked by git (not ignored/untracked ones), matching the
@@ -10,7 +16,7 @@ cd "$root" || exit 1
 set_permissions() {
     perm="$1"
     shift
-    echo "Setting permissions $perm for: ${*:-<all tracked files>}"
+    zz_log i "Setting permissions $perm for: ${*:-<all tracked files>}"
     git ls-files -z "$@" | xargs -0 -r chmod "$perm"
 }
 
@@ -21,9 +27,9 @@ set_permissions 600 '*.conf' '*.env'
 
 # Directories default to 755 (git does not track directories, so derive them
 # from the working tree, excluding the .git internals)
-find "$root" -type d -not -path '*/.git' -not -path '*/.git/*' -exec chmod 755 {} +
+find "." -type d -not -path '*/.git' -not -path '*/.git/*' -exec chmod 755 {} +
 
 # Tighten well-known sensitive directories (e.g. logs, cache) to 700
-find "$root" -type d \( -name logs -o -name cache \) -not -path '*/.git/*' -exec chmod 700 {} +
+find "." -type d \( -name logs -o -name cache \) -not -path '*/.git/*' -exec chmod 700 {} +
 
-echo "Access rights have been set according to best practices."
+zz_log s "Access rights have been set according to best practices."

--- a/src/gitutils/_git-fix-rights.sh
+++ b/src/gitutils/_git-fix-rights.sh
@@ -1,31 +1,29 @@
 #!/bin/sh
 
 #### GOTO DIRECTORY
-cd "$(git rev-parse --show-toplevel)"
+root="$(git rev-parse --show-toplevel)"
+cd "$root" || exit 1
 
+# Apply the given permission to the tracked files matching the given pathspecs.
+# Operates on files tracked by git (not ignored/untracked ones), matching the
+# stated intent of normalising the repository's own file permissions.
 set_permissions() {
-    local type="$1"
-    local name="$2"
-    local perm="$3"
-    echo "Setting permissions $perm for type <$type> with name pattern '$name'"
-    git ls-files -o -i --exclude-standard | grep -v '/$' | xargs -I {} find "{}" -type "$type" -name "$name" -exec chmod "$perm" {} \;
+    perm="$1"
+    shift
+    echo "Setting permissions $perm for: ${*:-<all tracked files>}"
+    git ls-files -z "$@" | xargs -0 -r chmod "$perm"
 }
 
-# Set default permissions for directories
-set_permissions d "*" 755
+# Regular files default to 644, scripts to 755, sensitive files to 600
+set_permissions 644
+set_permissions 755 '*.sh'
+set_permissions 600 '*.conf' '*.env'
 
-# Set default permissions for regular files
-set_permissions f "*" 644
+# Directories default to 755 (git does not track directories, so derive them
+# from the working tree, excluding the .git internals)
+find "$root" -type d -not -path '*/.git' -not -path '*/.git/*' -exec chmod 755 {} +
 
-# Set permissions for executable files (e.g., scripts)
-set_permissions f "*.sh" 755
-
-# Set permissions for sensitive files (e.g., configuration files)
-set_permissions f "*.conf" 600
-set_permissions f "*.env" 600
-
-# Set permissions for specific directories (e.g., logs, cache)
-set_permissions d "logs" 700
-set_permissions d "cache" 700
+# Tighten well-known sensitive directories (e.g. logs, cache) to 700
+find "$root" -type d \( -name logs -o -name cache \) -not -path '*/.git/*' -exec chmod 700 {} +
 
 echo "Access rights have been set according to best practices."

--- a/src/gitutils/_git-getcommit.sh
+++ b/src/gitutils/_git-getcommit.sh
@@ -19,11 +19,10 @@ if [ -z "$sha" ]; then
     if [ -n "$force" ]; then
         zz_log w "Force mode enabled, overwriting pushed history"
         git forceable >&2
-        read -p 'Which commit? ' sha
     else
         git fixable >&2
-        read -p 'Which commit? ' sha
     fi
+    sha=$(zz_prompt "Which commit?")
 fi
 
 

--- a/src/gitutils/_git-release-alpha.sh
+++ b/src/gitutils/_git-release-alpha.sh
@@ -66,6 +66,7 @@ elif [ -n "$occ" ]; then
     msg=$(echo "$msg" | sed -E "s/^( *[a-z]+)/$first_word/")
     zz_log i "Most occurring first word is '$first_word', updating commit message to start with it..."
 elif echo "$all_types" | grep -q '^ *feat'; then
+    first_word=feat
     msg=$(echo "$msg" | sed -E "s/^( *[a-z]+)/$first_word/")
     zz_log i "At least one commit message starts with 'feat', updating commit message to start with it..."
 else

--- a/src/gitutils/_git-release-beta.sh
+++ b/src/gitutils/_git-release-beta.sh
@@ -4,16 +4,28 @@
 cd "$(git rev-parse --show-toplevel)" >/dev/null
 
 #### EXIT IF OTHER RELEASE EXISTS
-if [ -f .git/RELEASE ] && [ -n "$(git branch --list release/* | grep -v $(cat .git/RELEASE))" ]; then
+if [ -f .git/RELEASE ] && [ -n "$(git branch --list 'release/*' | grep -v "$(cat .git/RELEASE)")" ]; then
     zz_log e "Other release exists, cannot proceed"
     exit 1
 fi
 
 #### GET BUMP VERSION
-GBV=$(gv -showvariable MajorMinorPatch | tee .git/RELEASE)
+GBV=$(gv -showvariable MajorMinorPatch)
+if [ -z "$GBV" ]; then
+    zz_log e "Cannot compute release version"
+    exit 1
+fi
 
 #### PREVENT GIT EDITOR PROMPT
-GIT_EDITOR=:
+export GIT_EDITOR=:
 
 #### START RELEASE
-git flow release start $GBV && git push origin release/$GBV
+# Record the release state only once the branch actually exists, so a failed
+# start does not leave a stale .git/RELEASE behind for `git prod`/next `git beta`.
+if git flow release start "$GBV"; then
+    printf '%s\n' "$GBV" >.git/RELEASE
+    git push origin "release/$GBV"
+else
+    zz_log e "Failed to start release $GBV"
+    exit 1
+fi

--- a/src/gitutils/_git-release-hotfix.sh
+++ b/src/gitutils/_git-release-hotfix.sh
@@ -11,7 +11,7 @@ eval $(
 help
 )
 
-#### GET last vX.Y.Z tag on the main branch, removing the leading 'v' and replacing last number with 'X'
+#### GET last vX.Y.Z tag on the main branch and replace the last number with 'X' (leading 'v' is kept)
 main=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" main)
 
 if [ -z "$main" ]; then
@@ -28,7 +28,7 @@ if [ -n "$rebase" ]; then
 elif git log --reverse --pretty=oneline --format=%B develop --not origin/develop --no-merges | grep -vE "^$|^fix(\(.+\))?:" >/dev/null; then
     zz_log w "There are commits since $main that are not of type 'fix:', creating hotfix branch only"
     unset rebase
-elif [ -z "$stash" ]; then
+else
     zz_log i "All commits since $main are of type 'fix:', creating hotfix branch and rebasing current history + stash on top of it"
     rebase=true
 fi
@@ -52,12 +52,17 @@ else
 fi
 
 # Set GIT_EDITOR to no-op to avoid opening editor during rebase or cherry-pick
-GIT_EDITOR=:
+export GIT_EDITOR=:
 
 hotfix=$(echo "$main" | sed -E 's/([0-9]+)\.([0-9]+)\.([0-9]+)/\1.\2.X/')
 
-# Create hotfix branch
-git flow hotfix start $hotfix
+# Create hotfix branch (bail out if it fails, so we don't pop the stash or
+# rebase onto the wrong branch)
+if ! git flow hotfix start "$hotfix"; then
+    zz_log e "Failed to start hotfix branch $hotfix"
+    [ -n "$stash" ] && git stash pop --index
+    exit 1
+fi
 
 # If stash was used, pop it back
 if [ -n "$stash" ]; then
@@ -74,5 +79,3 @@ if [ -n "$rebase" ]; then
     git fix base -p hotfix/$hotfix develop
 
 fi
-    
-        

--- a/src/gitutils/_git-release-prod.sh
+++ b/src/gitutils/_git-release-prod.sh
@@ -10,9 +10,9 @@ help
 cd "$(git rev-parse --show-toplevel)" >/dev/null
 
 # Check if on a hotfix branch and extract branch name
-if [ -n "$(git branch --list hotfix/*)" ]; then
+if [ -n "$(git branch --list 'hotfix/*')" ]; then
     flow=hotfix
-    name=$(git branch --list hotfix/* | sed 's/.*hotfix\///'| head -n1 )
+    name=$(git branch --list 'hotfix/*' | sed 's/.*hotfix\///'| head -n1 )
     zz_log i "Hotfix branch found: {Yellow $name}"
 
 # Check for .git/RELEASE file if no flow branch found
@@ -22,9 +22,9 @@ elif [ -z "$flow" ] && [ -f .git/RELEASE ]; then
     zz_log i "Release branch found: {Blue $name}"
 
 # Check if on a release branch and extract branch name
-elif [ -n "$(git branch --list release/*)" ]; then
+elif [ -n "$(git branch --list 'release/*')" ]; then
     flow=release
-    name=$(git branch --list release/* | sed 's/.*release\///' | head -n1 )
+    name=$(git branch --list 'release/*' | sed 's/.*release\///' | head -n1 )
     zz_log i "Release branch found: {Blue $name}"
 fi
 
@@ -49,13 +49,13 @@ fi
 
 
 # Ensure main branch has an up to-date remote
-if ! git fetch $(git remote) >/dev/null 2>&1; then
+if ! git fetch origin >/dev/null 2>&1; then
     zz_log e "Cannot fetch from remote"
     exit 1
 fi
 
 # Ensure main branch is up-to-date
-if ! git merge-base --is-ancestor $(git rev-parse $flow/$name) $(git rev-parse refs/remotes/$(git remote)/$flow/$name) ; then
+if ! git merge-base --is-ancestor $(git rev-parse $flow/$name) $(git rev-parse refs/remotes/origin/$flow/$name) ; then
     zz_log e "$flow/$name branch is not up-to-date with remote. Please pull the latest changes."
     exit 1
 fi
@@ -69,7 +69,7 @@ fi
 zz_log i "Bump version: {Blue $GBV}"
 
 # Prevent git editor prompt during finish
-GIT_EDITOR=:
+export GIT_EDITOR=:
 
 # Update version, changelog, and finish release
 if bump-changelog -f $GBV -b -m; then
@@ -78,7 +78,7 @@ if bump-changelog -f $GBV -b -m; then
         zz_log e "Cannot commit version & CHANGELOG"
         exit 1
     else
-        git push --set-upstream $(git remote) $flow/$name
+        git push --set-upstream origin $flow/$name
         zz_log s "Version & CHANGELOG committed and pushed"
     fi
 
@@ -93,17 +93,19 @@ if bump-changelog -f $GBV -b -m; then
         exit 1
     fi
 
-    if git flow $flow finish $name --push --tagname $GBV --message $GBV ; then
+    # Tag with the configured 'v' prefix so git-flow's tag matches the one
+    # bump-tag maintains (avoids a stray numeric tag alongside v$GBV).
+    if git flow $flow finish $name --push --tagname "v$GBV" --message $GBV ; then
         zz_log s "Release finished: {B $GBV}"
         bump-tag $GBV
+        # Clear release state only once the release has actually finished.
+        rm -f .git/RELEASE
     else
         zz_log e "Cannot finish release. CHANGELOG & VERSION are not updated."
         zz_log - "Please fix the issues, commit the changes, and finish the release manually with:"
-        zz_log - "   git flow $flow finish $name --push --tagname $GBV --message $GBV"
+        zz_log - "   git flow $flow finish $name --push --tagname v$GBV --message $GBV"
         zz_log - "   bump-tag $GBV"
     fi
-
-    rm -f .git/RELEASE  
 else
     zz_log e "Cannot update version & finish release"
 fi

--- a/src/gitutils/_git-unset.sh
+++ b/src/gitutils/_git-unset.sh
@@ -3,8 +3,6 @@
 #### Goto repository root
 cd "$(git rev-parse --show-toplevel)" >/dev/null
 
-echo git config ${2:---local} --get-regexp "^${1:-[a-z]+}\\."
-
 #### Unset all git config keys starting with the given prefix
 git config ${2:---local} --get-regexp "^${1:-[a-z]+}\\." | cut -d ' ' -f 1 | while read alias_key; do
      git config ${2:---local} --unset-all "$alias_key"

--- a/src/gitutils/alias.json
+++ b/src/gitutils/alias.json
@@ -128,7 +128,7 @@
         "help": "Fetch, stash, fast-forward merge, and restore stash."
     },
     "tidy": {
-        "cmd": "git branch --format=\"%(refname:short)\" | grep -v \"main\" |  grep -v \"dev\" | awk '{ printf(\"Delete %s? [y/n] \", $1); getline ans<\"/  dev/tty\"; if (ans == \"y\") { system(\"git branch -D \"$1 \">> ~/.gitdeletedbranches\"); } }'",
+        "cmd": "git branch --format=\"%(refname:short)\" | grep -v \"main\" |  grep -v \"dev\" | awk '{ printf(\"Delete %s? [y/n] \", $1); getline ans < \"/dev/tty\"; if (ans == \"y\") { system(\"git branch -D \"$1 \">> ~/.gitdeletedbranches\"); } }'",
         "help": "Interactively delete local branches except main and dev."
     },
     "undo": {

--- a/src/gitutils/config.json
+++ b/src/gitutils/config.json
@@ -1,7 +1,6 @@
 {
     "core": {
         "autocrlf": "input",
-        "editor": "code --wait",
         "filemode": false
     },
     "credential": {

--- a/src/gitutils/install-config.sh
+++ b/src/gitutils/install-config.sh
@@ -23,6 +23,12 @@ if [ -f "$source/config.json" ]; then
     done
 fi
 
+### Set the VS Code editor only when its CLI is available, so plain shells keep
+### their default git editor instead of a broken `code --wait` invocation.
+if command -v code >/dev/null 2>&1; then
+    git config $scope core.editor "code --wait" && zz_log - "Created config core.editor => code --wait"
+fi
+
 ### For each entry in alias.json file next to this file, create corresponding git alias from key and value
 if [ -f "$source/alias.json" ]; then
     zz_log i "Configuring aliases with {U $source/alias.json}..."

--- a/src/gitutils/package.json
+++ b/src/gitutils/package.json
@@ -13,7 +13,6 @@
         "stubs/**/*"
     ],
     "bin": {
-        "deleteChildren": "./_deleteChildren.sh",
         "git-align": "./_git-align.sh",
         "git-co": "./_git-co.sh",
         "git-degit": "./_git-degit.sh",
@@ -35,8 +34,7 @@
         "git-release-beta": "./_git-release-beta.sh",
         "git-release-hotfix": "./_git-release-hotfix.sh",
         "git-release-prod": "./_git-release-prod.sh",
-        "setrights": "./_setrights.sh",
-        "unset": "./_unset.sh"
+        "git-unset": "./_git-unset.sh"
     },
     "scripts": {
         "install": "if [ \"$INIT_CWD\" = \"$PWD\" ]; then sh ./install.sh; fi",


### PR DESCRIPTION
## Context

Deep review of the `gitutils` feature — understand it, challenge it, correct obvious errors, and lean up the dev experience. Findings were verified directly against the scripts; changes are scoped to correctness, safety and portability (no behavior-neutral churn). No new test harness (deferred).

## Correctness + docs
- **bin drift**: drop dead `deleteChildren` / `setrights` entries (files never existed); rename `_unset.sh` → `_git-unset.sh` so `git unset` actually dispatches — previously it installed as a bare `unset` command shadowing the shell builtin, and the documented `git unset` never worked.
- **release-alpha**: set `first_word=feat` in the `feat` fallback branch (it referenced an unset variable and wiped the commit type to empty).
- **fix-children**: drop the undefined `$force` passed to `git getcommit`.
- **alias `tidy`**: fix the stray-space `"/  dev/tty"` path so the delete prompt reads.
- **fix-lock**: correct the misleading "keep incoming" comment (the code keeps `--ours`).
- **README**: bump the quick-start pin `:5` → `:7`; remove documented-but-nonexistent commands (`movetags`, `crush`, `edit`, `fixMode`, `recallId`, `fixup`); map `git setrights` → `git fix rights`.

## Safety
- **fix-base** (data-loss): the cherry-pick loop ran in a `... | while` subshell, so its `failed` flag never propagated and the later destructive `git reset --hard` on the *source* branch was unguarded. Loop now runs in the current shell and bails before the reset on any failure.
- **align**: only `git stash pop` when a new stash entry was actually created (an unconditional pop on a clean tree consumed an unrelated, older stash).

## Portability
- Add a `zz_prompt` free-form input helper to **common-utils** and use it in `getcommit` and `fix-message` instead of non-POSIX `read -p` (fails under dash / Debian `/bin/sh`).
- **fix-rights**: operate on tracked files (was `git ls-files -o -i`, i.e. *ignored* files only) and drop the `local` bash-ism — POSIX-clean.
- **config**: set `core.editor "code --wait"` only when the `code` CLI is present, so plain shells keep a working git editor.

## Release tooling
- **export GIT_EDITOR** in beta / hotfix / prod — it was set unexported, so child `git flow` / `git commit` processes never saw it and could open an editor and hang in CI (alpha already exported it).
- **beta**: validate the version and write `.git/RELEASE` only after a successful `release start`, so a failure leaves no stale state to mislead `git prod` / the next `git beta`.
- **hotfix**: decouple the auto-rebase decision from the `-s` stash flag; guard `hotfix start` before popping the stash / rebasing; fix the comment/code `v`-prefix mismatch.
- **prod**: quote branch globs, use `origin` explicitly (was `$(git remote)`, which breaks with multiple remotes), finish with a `v`-prefixed tag so git-flow's tag matches the one `bump-tag` maintains (avoids a duplicate numeric tag), and clear `.git/RELEASE` only on a successful finish.

## Verification
- `sh -n` + `dash -n` on every edited script; `jq` validity on all edited JSON; `prettier` clean.
- Functionally verified the new `zz_prompt` (stdout = value, prompt → stderr, default fallback, dash-safe) and the two data-loss-critical fixes (fix-base loop propagation; align stash before/after guard).
- git-flow is not installed in this environment, so the full `git beta && git prod` smoke (`.github/workflows/release-main.yml`) was not run here. The prod `--tagname "v$GBV"` change relies on gitflow-avh's `-T` semantics (replaces the full tag name — no prefix concatenation, so no `vv…`).

Draft pending CI (`git beta && git prod` smoke) and review.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jqZTH5oJqQ4BS1jQkUJLd)_