### PR TITLE
fix(common-utils): 🔧 improve npx help/stubs/logs and drop deprecated deps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,11 +6,14 @@ source=$(dirname $(readlink -f $0))
 # Source the common utils
 . $source/src/common-utils/_zz_colors.sh
 
+# Internal debug logging: quiet by default, enable with ZZ_LOG_DEBUG=1
+_debug() { [ -n "${ZZ_LOG_DEBUG:-}" ] && echo "${Yellow}$*${End}" >&2 || true; }
+
 # Link common utils into src/ for easier sourcing during installation, and ensure they are cleaned up on exit
 
 links_up()
 {
-    echo "${Yellow}Link common utils${End}"
+    _debug "Link common utils"
     find $source/src/common-utils/ -type f -name "_*.sh" -exec echo {} \; -exec chmod +x {} \; | while read file; do
         ln -sf $file $source/src/common-utils/$(basename $file | sed 's/^_//;s/.sh$//')
     done
@@ -18,7 +21,7 @@ links_up()
 
 links_down()
 {
-    echo "${Yellow}Unlink common utils${End}"
+    _debug "Unlink common utils"
     find $source/src/common-utils/ -type f -name "_*.sh" -exec echo {} \; -exec chmod +x {} \; | while read file; do
         rm $source/src/common-utils/$(basename $file | sed 's/^_//;s/.sh$//')
     done
@@ -34,8 +37,8 @@ export PATH=$PATH:$source/src/common-utils
 
 eval $(
     zz_args "Manage devcontainer features" $0 "$@" <<-help
-    - command   cmd     Command to run: init list deps add remove update
-    + target    target  Feature name, -a (all available), or -x (defaults)
+    - command   cmd     Command: init|list|deps|add|remove|update|help
+    + target    target  Feature name(s), -a (all), -x (defaults), or empty to auto-detect
 help
 )
 
@@ -89,8 +92,44 @@ resolve_features() {
 
 # --- subcommands ---
 
+# Count stub files (regular files + symlinks) under a feature's stubs directory
+count_stubs() {
+    _dir="$1"
+    [ -d "$_dir" ] || { echo 0; return; }
+    find "$_dir" \( -type f -o -type l \) 2>/dev/null | wc -l | tr -d ' '
+}
+
+cmd_help() {
+    zz_log i "{BBlue devcontainer-features} - manage tomgrv devcontainer features"
+    zz_log - ""
+    zz_log - "{Yellow Usage:} npx tomgrv/devcontainer-features -- <command> <target...>"
+    zz_log - ""
+    zz_log - "{Yellow Commands:}"
+    zz_log - "  init             Deploy root stubs into current repo"
+    zz_log - "  list   <target>  List selected features"
+    zz_log - "  deps   <target>  Show feature dependencies"
+    zz_log - "  add    <target>  Install / deploy feature stubs (default command)"
+    zz_log - "  remove <target>  Remove feature stubs"
+    zz_log - "  update <target>  Reinstall features (-a re-detects all)"
+    zz_log - "  help             Show this help"
+    zz_log - ""
+    zz_log - "{Yellow Targets:}"
+    zz_log - "  <name>...  One or more feature names (e.g. githooks gitversion)"
+    zz_log - "  -a         All features available in src/"
+    zz_log - "  -x         Default features from stubs devcontainer.json"
+    zz_log - "  (empty)    Auto-detect from .devcontainer/*/devcontainer.json"
+    zz_log - ""
+    zz_log - "{Yellow Examples:}"
+    zz_log - "  npx tomgrv/devcontainer-features -- add -x"
+    zz_log - "  npx tomgrv/devcontainer-features -- add githooks gitversion"
+    zz_log - "  npx tomgrv/devcontainer-features -- list -a"
+    zz_log - "  npx tomgrv/devcontainer-features -- deps gitversion"
+    zz_log - ""
+    zz_log - "Set {U ZZ_LOG_DEBUG=1} for verbose internal logs."
+}
+
 cmd_init() {
-    zz_log i "Deploying root stubs..."
+    zz_log i "Deploying $(count_stubs "$source/stubs") root stub(s)..."
     sh "$source/src/common-utils/_configure-feature.sh" -s "$source" .
     zz_log s "Root stubs deployed"
 }
@@ -134,8 +173,10 @@ cmd_add() {
     zz_log i "Adding: $(echo $_features | tr '\n' ' ')"
     for _feature in $(echo "$_features" | tr '\n' ' '); do
         [ -z "$_feature" ] && continue
+        zz_log i "Deploying {Purple $_feature} ($(count_stubs "$source/src/$_feature/stubs") stub(s))..."
         sh "$source/install-feat.sh" "$source" "$_feature"
     done
+    zz_log s "Done adding features"
 }
 
 cmd_remove() {
@@ -147,17 +188,17 @@ cmd_remove() {
 
     for _feature in $(echo "$_features" | tr '\n' ' '); do
         [ -z "$_feature" ] && continue
-        zz_log i "Removing $_feature stubs..."
         _stub_src="$source/src/$_feature/stubs"
         if [ ! -d "$_stub_src" ]; then
             zz_log w "No stubs found for $_feature"
             continue
         fi
+        zz_log i "Removing {Purple $_feature} stubs ($(count_stubs "$_stub_src") tracked)..."
         find "$_stub_src" -type f | while read _stub; do
             _rel="${_stub#$_stub_src/}"
             _dest=$(echo "$_rel" | sed 's|^\.\./||;s|/\.\./|/|g')
             if [ -f "$_dest" ]; then
-                zz_log i "Removing $_dest..."
+                zz_log - "Removing {U $_dest}..."
                 rm -f "$_dest"
             fi
         done
@@ -194,6 +235,7 @@ case "${cmd:-}" in
     add)    cmd_add ;;
     remove) cmd_remove ;;
     update) cmd_update ;;
+    help|-h|--help) cmd_help ;;
     "")
         # No command: auto-detect features and add them
         cmd_add

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
     "name": "@tomgrv/devcontainer-features",
     "version": "7.3.6",
     "lockfileVersion": 3,
+    "requires": true,
     "packages": {
         "": {
             "name": "@tomgrv/devcontainer-features",
@@ -31,7 +32,6 @@
                 "@commitlint/cz-commitlint": "^19.2.0",
                 "commit-and-tag-version": "^12.4.1",
                 "commitizen": "^4.3.0",
-                "conventional-changelog-cli": "^2.1.1",
                 "devmoji": "^2.3.0",
                 "git-precommit-checks": "3.1.0",
                 "husky": "^9.0.11",
@@ -612,22 +612,6 @@
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
             "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
             "license": "MIT"
-        },
-        "node_modules/JSONStream": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-            "license": "(MIT OR Apache-2.0)",
-            "dependencies": {
-                "jsonparse": "^1.2.0",
-                "through": ">=2.2.7 <3"
-            },
-            "bin": {
-                "JSONStream": "bin.js"
-            },
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/add-stream": {
             "version": "1.0.0",
@@ -1530,368 +1514,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=14"
-            }
-        },
-        "node_modules/conventional-changelog-cli": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-2.2.2.tgz",
-            "integrity": "sha512-8grMV5Jo8S0kP3yoMeJxV2P5R6VJOqK72IiSV9t/4H5r/HiRqEBQ83bYGuz4Yzfdj4bjaAEhZN/FFbsFXr5bOA==",
-            "deprecated": "This package is no longer maintained. Please use the conventional-changelog package instead.",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "add-stream": "^1.0.0",
-                "conventional-changelog": "^3.1.24",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "tempfile": "^3.0.0"
-            },
-            "bin": {
-                "conventional-changelog": "cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog": {
-            "version": "3.1.25",
-            "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
-            "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "conventional-changelog-angular": "^5.0.12",
-                "conventional-changelog-atom": "^2.0.8",
-                "conventional-changelog-codemirror": "^2.0.8",
-                "conventional-changelog-conventionalcommits": "^4.5.0",
-                "conventional-changelog-core": "^4.2.1",
-                "conventional-changelog-ember": "^2.0.9",
-                "conventional-changelog-eslint": "^3.0.9",
-                "conventional-changelog-express": "^2.0.6",
-                "conventional-changelog-jquery": "^3.0.11",
-                "conventional-changelog-jshint": "^2.0.9",
-                "conventional-changelog-preset-loader": "^2.3.4"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-angular": {
-            "version": "5.0.13",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-            "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "compare-func": "^2.0.0",
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-atom": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
-            "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-codemirror": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
-            "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-conventionalcommits": {
-            "version": "4.6.3",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
-            "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "compare-func": "^2.0.0",
-                "lodash": "^4.17.15",
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-core": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
-            "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "add-stream": "^1.0.0",
-                "conventional-changelog-writer": "^5.0.0",
-                "conventional-commits-parser": "^3.2.0",
-                "dateformat": "^3.0.0",
-                "get-pkg-repo": "^4.0.0",
-                "git-raw-commits": "^2.0.8",
-                "git-remote-origin-url": "^2.0.0",
-                "git-semver-tags": "^4.1.1",
-                "lodash": "^4.17.15",
-                "normalize-package-data": "^3.0.0",
-                "q": "^1.5.1",
-                "read-pkg": "^3.0.0",
-                "read-pkg-up": "^3.0.0",
-                "through2": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-ember": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
-            "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-eslint": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
-            "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-express": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
-            "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-jquery": {
-            "version": "3.0.11",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
-            "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-jshint": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
-            "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "compare-func": "^2.0.0",
-                "q": "^1.5.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-preset-loader": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
-            "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-changelog-writer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-            "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "conventional-commits-filter": "^2.0.7",
-                "dateformat": "^3.0.0",
-                "handlebars": "^4.7.7",
-                "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "semver": "^6.0.0",
-                "split": "^1.0.0",
-                "through2": "^4.0.0"
-            },
-            "bin": {
-                "conventional-changelog-writer": "cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-commits-filter": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-            "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "lodash.ismatch": "^4.4.0",
-                "modify-values": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/conventional-commits-parser": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-            "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "is-text-path": "^1.0.1",
-                "JSONStream": "^1.0.4",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "split2": "^3.0.0",
-                "through2": "^4.0.0"
-            },
-            "bin": {
-                "conventional-commits-parser": "cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/dargs": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
-            "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/git-raw-commits": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.11.tgz",
-            "integrity": "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==",
-            "deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "dargs": "^7.0.0",
-                "lodash": "^4.17.15",
-                "meow": "^8.0.0",
-                "split2": "^3.0.0",
-                "through2": "^4.0.0"
-            },
-            "bin": {
-                "git-raw-commits": "cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/git-semver-tags": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
-            "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
-            "deprecated": "This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "meow": "^8.0.0",
-                "semver": "^6.0.0"
-            },
-            "bin": {
-                "git-semver-tags": "cli.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/is-text-path": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
-            "integrity": "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "text-extensions": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/split2": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "readable-stream": "^3.0.0"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/text-extensions": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
-            "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
-        "node_modules/conventional-changelog-cli/node_modules/through2": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "readable-stream": "3"
             }
         },
         "node_modules/conventional-changelog-codemirror": {
@@ -3943,6 +3565,22 @@
             ],
             "license": "MIT"
         },
+        "node_modules/JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "license": "(MIT OR Apache-2.0)",
+            "dependencies": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            },
+            "bin": {
+                "JSONStream": "bin.js"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -5232,18 +4870,6 @@
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "license": "MIT"
         },
-        "node_modules/q": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-            "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-            "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.6.0",
-                "teleport": ">=0.2.0"
-            }
-        },
         "node_modules/quick-lru": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -5731,6 +5357,15 @@
                 "node": ">= 10.x"
             }
         },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/string-argv": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -5761,15 +5396,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/string_decoder": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/strip-ansi": {
@@ -5863,41 +5489,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/temp-dir": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tempfile": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-3.0.0.tgz",
-            "integrity": "sha512-uNFCg478XovRi85iD42egu+eSFUmmka750Jy7L5tfHI5hQKKtbPnxaSaXAbBqCDYrw3wx4tXjKwci4/QmsZJxw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "temp-dir": "^2.0.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/tempfile/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "uuid": "bin/uuid"
             }
         },
         "node_modules/text-extensions": {
@@ -6092,13 +5683,16 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/validate-npm-package-license": {
@@ -6326,7 +5920,8 @@
                 "zz-input": "_zz_input.sh",
                 "zz-json": "_zz_json.sh",
                 "zz-log": "_zz_log.sh",
-                "zz-persist": "_zz_persist.sh"
+                "zz-persist": "_zz_persist.sh",
+                "zz-prompt": "_zz_prompt.sh"
             }
         },
         "src/gateway": {
@@ -6377,7 +5972,6 @@
             "version": "7.3.6",
             "hasInstallScript": true,
             "bin": {
-                "deleteChildren": "_deleteChildren.sh",
                 "git-align": "_git-align.sh",
                 "git-co": "_git-co.sh",
                 "git-degit": "_git-degit.sh",
@@ -6399,8 +5993,7 @@
                 "git-release-beta": "_git-release-beta.sh",
                 "git-release-hotfix": "_git-release-hotfix.sh",
                 "git-release-prod": "_git-release-prod.sh",
-                "setrights": "_setrights.sh",
-                "unset": "_unset.sh"
+                "git-unset": "_git-unset.sh"
             },
             "peerDependencies": {
                 "@tomgrv-devcontainer-features/common-utils": ">=5.0.0",
@@ -6460,6 +6053,5 @@
                 "@tomgrv-devcontainer-features/common-utils": ">=5.0.0"
             }
         }
-    },
-    "requires": true
+    }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "dependencies": {
         "prettier-plugin-sh": "^0.19.0"
     },
+    "overrides": {
+        "uuid": "^11.0.0"
+    },
     "devDependencies": {
         "npm-check-updates": "*"
     },
@@ -73,7 +76,6 @@
         "@commitlint/cz-commitlint": "^19.2.0",
         "commit-and-tag-version": "^12.4.1",
         "commitizen": "^4.3.0",
-        "conventional-changelog-cli": "^2.1.1",
         "devmoji": "^2.3.0",
         "git-precommit-checks": "3.1.0",
         "husky": "^9.0.11",

--- a/src/githooks/_commitlint.package.json
+++ b/src/githooks/_commitlint.package.json
@@ -9,8 +9,7 @@
         "@commitlint/config-conventional": "*",
         "@commitlint/core": "*",
         "@commitlint/cz-commitlint": "*",
-        "commitizen": "*",
-        "conventional-changelog-cli": "*"
+        "commitizen": "*"
     },
     "commitlint": {
         "extends": [


### PR DESCRIPTION
## What

Improves the `npx tomgrv/devcontainer-features` experience (help, stubs feedback, logs) and cuts npm deprecation warnings on install.

## npx usage (`install.sh`)

- **help**: new `help` / `-h` / `--help` command printing usage, command list, target selectors (`-a` / `-x` / named / auto-detect) and copy-paste `npx` examples. Terse `-h` auto-help descriptions clarified too.
- **logs**: internal "Link/Unlink common utils" noise now quiet by default and gated behind `ZZ_LOG_DEBUG=1`, so a plain `list` / `deps` / `help` run is clean. Per-file removal log downgraded to indented level.
- **stubs**: `init`, `add` and `remove` now report the stub count per feature (e.g. `Deploying githooks (3 stub(s))...`), and `add` emits a final success line.

## npm deprecation warnings

- Removed unused `conventional-changelog-cli` from root `peerDependencies` and `src/githooks/_commitlint.package.json`. It was never invoked (`release` uses `commit-and-tag-version`) yet dragged in the whole abandoned chain: `q`, `uuid@3`, `git-raw-commits@2`, `git-semver-tags@4`, `inflight`, `glob@7` and the deprecated `conventional-changelog-*@2.0.x` presets.
- Added `overrides: { "uuid": "^11.0.0" }` to clear the `uuid` deprecation warning (resolves to 11.1.1; `commit-and-tag-version` release dry-run verified working).

The few remaining warnings come from transitive deps of `commitizen` and `commit-and-tag-version` at their **latest** versions (glob@7→inflight, and the `conventional-changelog@4` preset metapackage). Every published version of those leaf packages is deprecated, so a version override cannot silence them without breaking the release tooling — they need upstream fixes.

## Testing

- `sh -n install.sh` passes; manually exercised `help`, `-h`, `list -a`, `deps`, `remove` (temp dir), unknown-command path, and `ZZ_LOG_DEBUG=1`.
- Fresh `npm install` deprecation warnings dropped from ~20+ to a small residual upstream set.
- `commit-and-tag-version --dry-run` still produces the changelog/tag correctly with the uuid override.

## Notes

- `package-lock.json` regenerated surgically (net −446/+38 lines, removing the cli subtree).
- Kept minimal: no `.sh` prettier reformat (repo does not format shell), no touching pre-existing prettier drift in `_commitlint.package.json`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyVKHzaHGuoqxkcYuyP4rr)_