### PR TITLE
fix(gitutils): 🐛 stop double v-prefix in release tags

### DIFF
--- a/src/gitutils/_git-release-prod.sh
+++ b/src/gitutils/_git-release-prod.sh
@@ -93,9 +93,9 @@ if bump-changelog -f $GBV -b -m; then
         exit 1
     fi
 
-    # Tag with the configured 'v' prefix so git-flow's tag matches the one
-    # bump-tag maintains (avoids a stray numeric tag alongside v$GBV).
-    if git flow $flow finish $name --push --tagname "v$GBV" --message $GBV ; then
+    # git flow finish prepends gitflow.prefix.versiontag to --tagname itself,
+    # so pass the bare version here -- prefixing it ourselves would tag "vv$GBV".
+    if git flow $flow finish $name --push --tagname "$GBV" --message $GBV ; then
         zz_log s "Release finished: {B $GBV}"
         bump-tag $GBV
         # Clear release state only once the release has actually finished.
@@ -103,7 +103,7 @@ if bump-changelog -f $GBV -b -m; then
     else
         zz_log e "Cannot finish release. CHANGELOG & VERSION are not updated."
         zz_log - "Please fix the issues, commit the changes, and finish the release manually with:"
-        zz_log - "   git flow $flow finish $name --push --tagname v$GBV --message $GBV"
+        zz_log - "   git flow $flow finish $name --push --tagname $GBV --message $GBV"
         zz_log - "   bump-tag $GBV"
     fi
 else


### PR DESCRIPTION
## Summary

- `git flow $flow finish --tagname` already prepends `gitflow.prefix.versiontag` (default `v`) to whatever is passed.
- `_git-release-prod.sh` was manually prepending `v` before calling it (`--tagname "v$GBV"`), producing tags like `vv1.2.3` instead of `v1.2.3`.
- Now passes the bare version (`--tagname "$GBV"`) so git-flow applies the configured prefix exactly once, matching what `bump-tag` produces afterward.

## Test plan

- [ ] Manual: run through a release finish flow in a gitflow-initialized repo and confirm the resulting tag is `v<version>`, not `vv<version>`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XeLkCSrGBLgggCA3PYxkHa)_