### PR TITLE
feat(gitutils): add git fix prune to remove stale remote-tracking refs

### DIFF
--- a/src/gitutils/README.md
+++ b/src/gitutils/README.md
@@ -67,6 +67,7 @@ The feature includes the following interactive utilities:
 - `git fix date [options] [<commit>]` - Fix commit dates and times in git history. Options include rescheduling commits on specific days of week outside certain time ranges.
 - `git fix blanks [-d]` - Discard tracked text-file changes when differences are only whitespace, blanks, and quote/slash swaps.
 - `git fix message -m <message> [--force|<commit>]` - Rewrite the commit message of a specific commit.
+- `git fix prune [<remote>]` - Prune remote-tracking references that no longer exist on the remote (defaults to all remotes). Runs automatically on `postStartCommand`.
 - `git fix secrets -g <glob> -s <secret> [-r <replace>] [-f] [-p] [-d] [-m] [-t] [<commit>]` - Redact a secret from files matching a glob pattern (and optionally commit messages and tag annotations) across all git history, replacing it with `****` (or `-r <replace>`).
 - `git fix up [--force|<commit>]` - Amend the specified commit with current changes and rebase (alias: `git fu`).
 - `git forall <command>` - Execute a command for all files in the repository.

--- a/src/gitutils/_git-fix-prune.sh
+++ b/src/gitutils/_git-fix-prune.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Function to print help and manage arguments
+eval $(
+	zz_args "Prune remote-tracking references that no longer exist on the remote" $0 "$@" <<-help
+		- remote remote     remote to prune (default: all remotes)
+	help
+)
+
+# Navigate to the repository root
+cd "$(git rev-parse --show-toplevel)" >/dev/null
+
+remotes="${remote:-$(git remote)}"
+
+for r in $remotes; do
+	zz_log i "Pruning stale remote-tracking references for $r"
+	git remote prune "$r"
+done
+
+zz_log s "Remote-tracking references pruned."

--- a/src/gitutils/devcontainer-feature.json
+++ b/src/gitutils/devcontainer-feature.json
@@ -42,6 +42,7 @@
     },
     "postStartCommand": {
         "blanks": "git fix blanks",
-        "files": "git fix mode"
+        "files": "git fix mode",
+        "prune": "git fix prune"
     }
 }

--- a/src/gitutils/package.json
+++ b/src/gitutils/package.json
@@ -24,6 +24,7 @@
         "git-fix-lock": "./_git-fix-lock.sh",
         "git-fix-mode": "./_git-fix-mode.sh",
         "git-fix-privacy": "./_git-fix-privacy.sh",
+        "git-fix-prune": "./_git-fix-prune.sh",
         "git-fix-secrets": "./_git-fix-secrets.sh",
         "git-fix-up": "./_git-fix-up.sh",
         "git-forall": "./_git-forall.sh",


### PR DESCRIPTION
## Summary
- Add `_git-fix-prune.sh` (`git fix prune [<remote>]`) — prunes remote-tracking refs deleted on the remote via `git remote prune`, defaulting to all remotes.
- Register `git-fix-prune` in `package.json` bin entries.
- Wire it into `postStartCommand` in `devcontainer-feature.json` so it runs automatically alongside the existing `blanks`/`mode` fixes.
- Document the new command in `README.md`.

## Test plan
- [ ] `sh -n src/gitutils/_git-fix-prune.sh` (syntax check, done)
- [ ] Manually run `git fix prune` in a repo with a deleted remote branch and confirm the local remote-tracking ref is removed
- [ ] Confirm `configure-feature gitutils` / container rebuild runs `git fix prune` on start without error

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZF1u2AEABseP21tWhnYhM)_