### PR TITLE
fix(install): accept bare feature name as shorthand for add

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ npx tomgrv/devcontainer-features -- init
 npx tomgrv/devcontainer-features -- add gitutils
 ```
 
+A bare feature name is also accepted as shorthand for `add <name>`:
+
+```sh
+npx tomgrv/devcontainer-features -- gitutils
+```
+
 #### To set up a full dev environment
 
 ```sh

--- a/install.sh
+++ b/install.sh
@@ -124,6 +124,7 @@ cmd_help() {
     zz_log - "  npx tomgrv/devcontainer-features -- add githooks gitversion"
     zz_log - "  npx tomgrv/devcontainer-features -- list -a"
     zz_log - "  npx tomgrv/devcontainer-features -- deps gitversion"
+    zz_log - "  npx tomgrv/devcontainer-features -- gitutils  (shorthand for {U add gitutils})"
     zz_log - ""
     zz_log - "Set {U ZZ_LOG_DEBUG=1} for verbose internal logs."
 }
@@ -241,7 +242,13 @@ case "${cmd:-}" in
         cmd_add
         ;;
     *)
-        zz_log e "Unknown command: $cmd"
-        exit 1
+        # Shorthand: a bare feature name (no "add") is treated as "add <name>"
+        if [ -d "$source/src/$cmd" ] && [ "$cmd" != "common-utils" ]; then
+            target="$cmd${target:+ $target}"
+            cmd_add
+        else
+            zz_log e "Unknown command: $cmd"
+            exit 1
+        fi
         ;;
 esac


### PR DESCRIPTION
## Summary

- `npm exec --package github:tomgrv/devcontainer-features -- devcontainer-features -- gitutils` (used by consumers such as `perspikapps/flekskit`'s CI, [failing run](https://github.com/perspikapps/flekskit/actions/runs/31514619403/job/93856554313)) fails with `✕ Unknown command: gitutils`.
- Root cause: the literal `--` in that invocation is consumed by `getopts` as the end-of-options marker inside `_zz_args.sh`, which drops the `add` command and leaves the feature name (`gitutils`) sitting in the `command` slot instead of `target`.
- Fix: when the parsed command doesn't match a known subcommand but does match a feature directory under `src/`, treat it as shorthand for `add <name>` instead of failing. Documented the shorthand in the README and CLI help.

## Test plan

- [x] `sh install.sh -- gitutils` in an empty dir installs the `gitutils` feature (previously would have errored, matching the shorthand form used by the failing CI invocation)
- [x] `sh install.sh -- add -a` still installs all features (regression check)
- [x] `sh install.sh -- bogus` still errors with `Unknown command: bogus` (regression check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVRevhVDTMyMJ9w5DFqKna)_