### PR TITLE
chore: 🔧 update lint-staged to exclude .agents/ from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+# Exclude .agents/ from prettier formatting
+# This is the canonical source for AI tooling; symlinked copies format via their own rules
+.agents/
+
+# Standard ignores
+node_modules/
+dist/
+build/
+.git/

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
         "!(*schema).json": [
             "normalize-json -c -w -a -i -t 4 -f local -l true"
         ],
-        "!(templates/**/*).{js,jsx,ts,tsx,md,html,css,vue,yaml,yml,json}": [
+        "!(templates/**/*|.agents/**).{js,jsx,ts,tsx,md,html,css,vue,yaml,yml,json}": [
             "npx --yes prettier --write"
         ],
         "*.php": [

--- a/src/ai-coding/stubs/.prettierignore
+++ b/src/ai-coding/stubs/.prettierignore
@@ -1,0 +1,9 @@
+# Exclude .agents/ from prettier formatting
+# This is the canonical source for AI tooling; symlinked copies format via their own rules
+.agents/
+
+# Standard ignores
+node_modules/
+dist/
+build/
+.git/


### PR DESCRIPTION
## Summary

Excludes `.agents/` directory from prettier formatting to prevent redundant formatting of both canonical source and symlinked copies.

## Changes

- Created `.prettierignore` to exclude `.agents/` directory
- Updated lint-staged glob pattern to exclude `.agents/` from prettier processing

## Rationale

Per repo dogfooding pattern, `.agents/` is the canonical source for AI tooling. Symlinked copies in `.github/skills/` and `.claude/skills/` format via their own rules. This prevents duplicate formatting runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_017GPULCh172fSnGZo5MJGwU)_