### PR TITLE
fix(common-utils): 🐛 dedupe array-of-array elements correctly in merge-json

### DIFF
--- a/src/common-utils/_merge-json.sh
+++ b/src/common-utils/_merge-json.sh
@@ -37,7 +37,7 @@ zz_log i "Merging JSON from {U $source} into {U $target}..."
 
 # Merge the source JSON into the target JSON
 jq 'def dedupe_ordered:
-  reduce .[] as $x ([]; if (index($x) != null) then . else . + [$x] end);
+  reduce .[] as $x ([]; if any(.[]; . == $x) then . else . + [$x] end);
 
 def merge($a; $b):
   if ($a | type) == "object" and ($b | type) == "object" then

--- a/src/common-utils/tests/test-merge.sh
+++ b/src/common-utils/tests/test-merge.sh
@@ -7,14 +7,14 @@ work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
 
 # --- source order is preserved: arrays keep first-seen order, not sorted ---
-cat >"$work/target.json" <<'EOF'
+cat > "$work/target.json" << 'EOF'
 {"a": 1, "b": [1, 2, 3], "c": {"x": 1}}
 EOF
-cat >"$work/source.json" <<'EOF'
+cat > "$work/source.json" << 'EOF'
 {"b": [3, 4, 5], "d": 9, "c": {"y": 2}}
 EOF
 
-merge-json "$work/target.json" "$work/source.json" >/dev/null 2>&1
+merge-json "$work/target.json" "$work/source.json" > /dev/null 2>&1
 
 assert_eq "array merge keeps first-seen order (no sort)" \
     "[1,2,3,4,5]" \
@@ -29,27 +29,43 @@ assert_eq "nested objects are merged" \
     "$(jq -c '.c' "$work/target.json")"
 
 # --- array merge dedupes ---
-cat >"$work/target2.json" <<'EOF'
+cat > "$work/target2.json" << 'EOF'
 {"tags": ["a", "b"]}
 EOF
-cat >"$work/source2.json" <<'EOF'
+cat > "$work/source2.json" << 'EOF'
 {"tags": ["b", "c"]}
 EOF
 
-merge-json "$work/target2.json" "$work/source2.json" >/dev/null 2>&1
+merge-json "$work/target2.json" "$work/source2.json" > /dev/null 2>&1
 
 assert_eq "array merge dedupes repeated values" \
     '["a","b","c"]' \
     "$(jq -c '.tags' "$work/target2.json")"
 
+# --- array merge dedupes when elements are themselves arrays (jq's ---
+# --- `index` treats an array needle as a subsequence pattern, not an ---
+# --- element to match, so a naive index-based dedupe silently fails) ---
+cat > "$work/target3.json" << 'EOF'
+{"pairs": [[1, 2], [3, 4]]}
+EOF
+cat > "$work/source3.json" << 'EOF'
+{"pairs": [[1, 2], [5, 6]]}
+EOF
+
+merge-json "$work/target3.json" "$work/source3.json" > /dev/null 2>&1
+
+assert_eq "array merge dedupes repeated array elements" \
+    '[[1,2],[3,4],[5,6]]' \
+    "$(jq -c '.pairs' "$work/target3.json")"
+
 # --- error cases ---
 status=0
-merge-json "$work/missing.json" "$work/source.json" >/dev/null 2>&1 || status=$?
+merge-json "$work/missing.json" "$work/source.json" > /dev/null 2>&1 || status=$?
 assert_status "missing target file fails" 1 "$status"
 
-echo "not json" >"$work/invalid.json"
+echo "not json" > "$work/invalid.json"
 status=0
-merge-json "$work/invalid.json" "$work/source.json" >/dev/null 2>&1 || status=$?
+merge-json "$work/invalid.json" "$work/source.json" > /dev/null 2>&1 || status=$?
 assert_status "invalid target JSON fails" 1 "$status"
 
 report


### PR DESCRIPTION
## Summary
- `_merge-json.sh`'s `dedupe_ordered` helper used jq's `index($x)` to detect already-seen array elements. jq's `index` treats an array argument as a subsequence pattern to search for within the input, not as a single element to compare against — so when merged array elements were themselves arrays (e.g. `[[1,2],[3,4]]`), `index($x)` never matched, and the merge silently duplicated instead of deduping.
- Fixed by switching to `any(.[]; . == $x)` for element-wise equality, which works for arrays, objects, and scalars alike.

## Test plan
- [x] Added `tests/test-merge.sh` case merging `{"pairs":[[1,2],[3,4]]}` with `{"pairs":[[1,2],[5,6]]}`, asserting the result is `[[1,2],[3,4],[5,6]]` (no duplicate `[1,2]`).
- [x] `sh src/common-utils/tests/run.sh` — all suites pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8ebEcHjZcDXiEhsQQoxZQ)_