### PR TITLE
feat(devcontainer-features-githooks): ✨ validate composer.json/package.json via lint-staged

### DIFF
--- a/.claude/hooks/lint-staged-precommit.sh
+++ b/.claude/hooks/lint-staged-precommit.sh
@@ -6,20 +6,19 @@
 # postCreateCommand pipeline that would otherwise wire this up.
 #
 # common-utils (normalize-json/etc., used by the lint-staged rules) is
-# fetched via `npm install` -- it's a published npm package
-# (@tomgrv-devcontainer-features/common-utils, declared as an
-# optionalDependency in package.json), not a local script. Fires as a
-# PreToolUse hook on Bash, filtered to `git commit` commands (see
-# .claude/settings.json).
+# resolved directly by package name and installed globally -- it does not
+# rely on this repo's package.json declaring it as a dependency, or on npm
+# workspace linking. Fires as a PreToolUse hook on Bash, filtered to
+# `git commit` commands (see .claude/settings.json).
 
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 cd "$repo_root" || exit 0
 
 [ -f package.json ] || exit 0
 
-if [ ! -x node_modules/.bin/normalize-json ]; then
-    npm install --no-audit --no-fund >&2 || {
-        echo "lint-staged-precommit.sh: npm install failed, skipping lint-staged" >&2
+if ! command -v normalize-json >/dev/null 2>&1; then
+    npm install -g @tomgrv-devcontainer-features/common-utils >&2 || {
+        echo "lint-staged-precommit.sh: npm install -g common-utils failed, skipping lint-staged" >&2
         exit 0
     }
 fi

--- a/.claude/hooks/lint-staged-precommit.sh
+++ b/.claude/hooks/lint-staged-precommit.sh
@@ -5,18 +5,21 @@
 # session. Sessions clone the repo directly and never run the devcontainer
 # postCreateCommand pipeline that would otherwise wire this up.
 #
-# Installs common-utils (normalize-json/etc., used by the lint-staged rules)
-# on first run only; idempotent after that. Fires as a PreToolUse hook on
-# Bash, filtered to `git commit` commands (see .claude/settings.json).
+# common-utils (normalize-json/etc., used by the lint-staged rules) is
+# fetched via `npm install` -- it's a published npm package
+# (@tomgrv-devcontainer-features/common-utils, declared as an
+# optionalDependency in package.json), not a local script. Fires as a
+# PreToolUse hook on Bash, filtered to `git commit` commands (see
+# .claude/settings.json).
 
 repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
 cd "$repo_root" || exit 0
 
 [ -f package.json ] || exit 0
 
-if ! command -v normalize-json >/dev/null 2>&1 && [ -f src/common-utils/install.sh ]; then
-    sh src/common-utils/install.sh >&2 || {
-        echo "lint-staged-precommit.sh: common-utils install failed, skipping lint-staged" >&2
+if [ ! -x node_modules/.bin/normalize-json ]; then
+    npm install --no-audit --no-fund >&2 || {
+        echo "lint-staged-precommit.sh: npm install failed, skipping lint-staged" >&2
         exit 0
     }
 fi

--- a/.claude/hooks/lint-staged-precommit.sh
+++ b/.claude/hooks/lint-staged-precommit.sh
@@ -17,7 +17,7 @@ cd "$repo_root" || exit 0
 [ -f package.json ] || exit 0
 
 if ! command -v normalize-json >/dev/null 2>&1; then
-    npm install -g @tomgrv-devcontainer-features/common-utils >&2 || {
+    npm install -g @tomgrv/devcontainer-features-common-utils >&2 || {
         echo "lint-staged-precommit.sh: npm install -g common-utils failed, skipping lint-staged" >&2
         exit 0
     }

--- a/.claude/hooks/lint-staged-precommit.sh
+++ b/.claude/hooks/lint-staged-precommit.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Runs lint-staged before `git commit`, so composer.json/package.json/etc.
+# get validated and normalized on every commit made during a Claude Code
+# session. Sessions clone the repo directly and never run the devcontainer
+# postCreateCommand pipeline that would otherwise wire this up.
+#
+# Installs common-utils (normalize-json/etc., used by the lint-staged rules)
+# on first run only; idempotent after that. Fires as a PreToolUse hook on
+# Bash, filtered to `git commit` commands (see .claude/settings.json).
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root" || exit 0
+
+[ -f package.json ] || exit 0
+
+if ! command -v normalize-json >/dev/null 2>&1 && [ -f src/common-utils/install.sh ]; then
+    sh src/common-utils/install.sh >&2 || {
+        echo "lint-staged-precommit.sh: common-utils install failed, skipping lint-staged" >&2
+        exit 0
+    }
+fi
+
+npx --yes lint-staged >&2
+status=$?
+
+if [ "$status" -ne 0 ]; then
+    echo "lint-staged-precommit.sh: lint-staged failed (exit $status), blocking commit" >&2
+    exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,18 @@
         "sessionUrl": false
     },
     "hooks": {
+        "PreToolUse": [
+            {
+                "hooks": [
+                    {
+                        "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/lint-staged-precommit.sh",
+                        "if": "Bash(git commit*)",
+                        "type": "command"
+                    }
+                ],
+                "matcher": "Bash"
+            }
+        ],
         "SessionStart": [
             {
                 "hooks": [

--- a/package.json
+++ b/package.json
@@ -199,6 +199,12 @@
         ],
         ".devcontainer/*": [
             "cp -u -t ./stubs/.devcontainer "
+        ],
+        "composer.json": [
+            "composer validate --no-check-all --no-check-lock --no-check-publish"
+        ],
+        "package.json": [
+            "npm pkg fix"
         ]
     },
     "validate-branch-name": {

--- a/src/common-utils/install.sh
+++ b/src/common-utils/install.sh
@@ -3,12 +3,18 @@
 ### Options
 UTILS="${UTILS:-"jq dos2unix"}"
 
+# Resolve this script's directory as an absolute path, regardless of whether
+# $0 was invoked relatively (cd src/common-utils && sh install.sh) or with an
+# already-absolute path (sh "$source/src/common-utils/install.sh", as used by
+# install-feat.sh / npx)
+dir=$(dirname $(readlink -f $0))
+
 ### Link to utils, retrieve name after _zz_ / before .sh and create a symlink
-find $PWD/$(dirname $0) -type f -name "_zz_*.sh" -exec basename {} \; | sed 's/_zz_\(.*\)\.sh/\1/' | while read util; do
-    chmod +x $PWD/$(dirname $0)/_zz_${util}.sh
-    ln -sf $PWD/$(dirname $0)/_zz_${util}.sh $PWD/$(dirname $0)/zz_${util}
+find $dir -type f -name "_zz_*.sh" -exec basename {} \; | sed 's/_zz_\(.*\)\.sh/\1/' | while read util; do
+    chmod +x $dir/_zz_${util}.sh
+    ln -sf $dir/_zz_${util}.sh $dir/zz_${util}
 done
-export PATH=$PWD/$(dirname $0):$PATH
+export PATH=$dir:$PATH
 
 ### Install utils
 for bin in $UTILS; do
@@ -32,5 +38,5 @@ for bin in $UTILS; do
 done >&2
 
 ### Run Installers
-$(dirname $0)/_install-feature.sh -s $PWD/$(dirname $0)
-$(dirname $0)/_install-bin.sh -s $PWD/$(dirname $0)
+$dir/_install-feature.sh -s $dir
+$dir/_install-bin.sh -s $dir

--- a/src/githooks/_lint-staged.package.json
+++ b/src/githooks/_lint-staged.package.json
@@ -9,11 +9,13 @@
         "prettier": "^3"
     },
     "lint-staged": {
-        "!(*schema).json": [
-            "normalize-json -c -w -a -i -t 4 -f local -l true"
-        ],
+        "!(*schema).json": ["normalize-json -c -w -a -i -t 4 -f local -l true"],
         "*.{js,jsx,ts,tsx,md,html,css,vue,yaml,yml,json}": [
             "npx --yes prettier --write"
-        ]
+        ],
+        "composer.json": [
+            "composer validate --no-check-all --no-check-lock --no-check-publish"
+        ],
+        "package.json": ["npm pkg fix"]
     }
 }


### PR DESCRIPTION
## Summary

- Add `lint-staged` rules for `composer.json` (`composer validate --no-check-all --no-check-lock --no-check-publish`) and `package.json` (`npm pkg fix`) so malformed manifest files are caught/normalized before commit, not just reformatted.
  - Added to `src/githooks/_lint-staged.package.json`, the base config this feature merges into every consumer's `package.json`.
  - Mirrored the same rules into the root `package.json`, which dogfoods `githooks`' own generated config for this repo's own pre-commit hooks.
  - `composer validate` is run without `--strict` so it fails only on real schema errors, not on cosmetic warnings (e.g. missing license) common in private packages.

- Fix `src/common-utils/install.sh`: it built paths as `$PWD/$(dirname $0)`, assuming `$0` is always relative. When invoked with an absolute path — the normal case for `install-feat.sh` and a real `npx tomgrv/devcontainer-features -- add common-utils` from an independent directory — `$PWD` got prepended onto an already-absolute path, producing a bogus doubled path that broke stub deployment and bin-linking entirely for any consumer installing this way. Fixed by resolving the script's own directory once via `readlink -f`, matching the convention already used in the root `install.sh`. Verified by packing the repo (`npm pack`) and installing it via `npx --package=<tarball> devcontainer-features add common-utils` from a completely fresh, unrelated directory.

- Add `.claude/hooks/lint-staged-precommit.sh` + a `PreToolUse`/`Bash` hook in `.claude/settings.json` (filtered to `git commit*`) so `lint-staged` actually runs before commits made during a Claude Code session. Sessions clone the repo directly and never run the devcontainer `postCreateCommand` pipeline that would otherwise wire up this repo's own pre-commit hooks, so without this, commits made in a session skipped lint-staged (and the new composer/package rules above) entirely. The hook installs `common-utils` on first run (idempotent after that) and blocks the commit (exit 2) if `lint-staged` fails.

## Test plan

- [x] `node -e "JSON.parse(...)"` on both edited lint-staged config files
- [x] `npx prettier --write` on both edited files
- [x] `composer validate --no-check-all --no-check-lock --no-check-publish` verified to exit 0 on a minimal valid `composer.json` and exit non-zero on schema errors
- [x] `npm pkg fix` verified against a copy of the root `package.json`
- [x] Full `lint-staged` run against both new rules in an isolated clone, confirmed `composer.json`/`package.json` rules fire and apply correctly
- [x] `npm pack` + `npx --package=<tarball> devcontainer-features add common-utils` from a fresh, independent directory — confirmed broken before the fix, confirmed working after (stubs deployed, global bins installed and functional)
- [x] Pipe-tested `.claude/hooks/lint-staged-precommit.sh` with a synthetic `PreToolUse`/`Bash` `git commit` payload — ran lint-staged successfully against real staged files, exit 0
- [x] Verified the blocking path in an isolated scratch repo with a deliberately failing `lint-staged` rule — hook correctly exits 2