### PR TITLE
fix(devcontainer-features-gateway): 🐛 recognize non-alnum-led flag clusters like -#0O

### DIFF
--- a/src/gateway/_gateway-curl.sh
+++ b/src/gateway/_gateway-curl.sh
@@ -190,9 +190,9 @@ main() {
             --*)
                 probe_args+=("$a")
                 ;;
-            -[a-zA-Z0-9]*)
+            -?*)
                 cluster="${a#-}"
-                if [[ "$cluster" =~ ^[sSfLkvigqnN460O]*o?$ ]]; then
+                if [[ "$cluster" =~ ^[sSfLkvigqnN460O#]*o?$ ]]; then
                     # Cluster of known boolean flags, optionally ending with -o <file>:
                     # strip -f/-O (re-applied on delivery) and split a trailing -o.
                     if [[ "$cluster" == *f* ]]; then


### PR DESCRIPTION
## Summary
- Follow-up to #118 — the `-0`/`-O` fixes there missed one case: the cluster-detection pattern `-[a-zA-Z0-9]*` required the first character after the dash to be alphanumeric
- A cluster starting with a non-alnum boolean flag (e.g. `-#`, progress-bar) fell through to the generic passthrough arg instead of the boolean-flag cluster parser, so any `-O` bundled further into that cluster was never recognized as remote-name
- Repro: `curl -s -#0O <url>` wrote the response to stdout instead of saving it to the URL-derived file name
- Widened the pattern to `-?*` and added `#` to the recognized boolean-flag set

## Test plan
- [x] `bash -n src/gateway/_gateway-curl.sh` (syntax check)
- [x] Ran the actual wrapper (as `_gateway-curl.sh` and installed as `gateway-curl`) against a local HTTP server:
  - `-s -#0O` → now writes the file, stdout empty (previously: 21 bytes to stdout, no file)
  - `-s -0O`, `-sO -0`, `-0o out.txt` still correct
  - bare `-0`/`-s` (no `-o`/`-O`) still correctly go to stdout, matching real curl
  - `-I`, `-J -O`, `-XPOST`, `-H` unaffected (regression check)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X5554kB3SoBHuBM8LU4Hf8)_