### PR TITLE
fix(devcontainer-features-githooks): 🐛 stop lockfile check from running lifecycle scripts

### DIFF
--- a/src/githooks/_pre-commit.sh
+++ b/src/githooks/_pre-commit.sh
@@ -30,11 +30,19 @@ if echo "$changed_files" | grep -q "package.json"; then
     # ensure that the package.json is valid and package-lock.json is up-to-date
     zz_log i "Ensure that the package.json is valid and package-lock.json is up-to-date..."
 
+    # --package-lock-only --ignore-scripts: recompute the lockfile without
+    # installing anything or running install/postinstall lifecycle scripts.
+    # A full `npm install --ws` here runs every workspace's lifecycle
+    # scripts on every commit that touches any package.json, which can
+    # rewrite arbitrary tracked files mid-hook — lint-staged's git-stash
+    # based backup/restore of the original staged snapshot then has to
+    # reconcile that unrelated noise, and unrelated staged changes can be
+    # dropped instead of committed.
     ws=$(npm pkg get workspaces)
     if test "$ws" = "undefined" || test "$ws" = "{}"; then
-        npm install --package-lock || true
+        npm install --package-lock-only --ignore-scripts || true
     else
-        npm install --package-lock --ws --if-present --include-workspace-root || true
+        npm install --package-lock-only --ignore-scripts --ws --if-present --include-workspace-root || true
     fi
 
     # commit the updated package-lock.json if file changed


### PR DESCRIPTION
## Summary

- The pre-commit hook's "keep package-lock.json in sync" step ran `npm install --ws --if-present --include-workspace-root` whenever **any** `package.json` changed — including a nested workspace one unrelated to the root. `--ws` without a specific `--workspace=<name>` runs install/postinstall lifecycle scripts across **every** workspace, not just the one that changed.
- Reproduced concretely: staging a change to a nested `package.json` (e.g. `src/gateway/package.json`) alongside an unrelated file, then running the hook chain, causes `ai-coding`'s workspace postinstall to re-fetch skills from GitHub and rewrite dozens of tracked files mid-hook. lint-staged's git-stash-based backup/restore of the *originally* staged snapshot then has to reconcile that unrelated noise — and empirically drops the unrelated staged file instead of committing it. Because lint-staged runs with `--allow-empty`, the commit still "succeeds" (empty or missing files) instead of failing loudly.
- Fix: swap `npm install --package-lock` / `--ws ...` for `npm install --package-lock-only --ignore-scripts` (with the same `--ws --if-present --include-workspace-root` flags where applicable). This recomputes `package-lock.json` — the step's actual stated purpose — without installing anything or running any lifecycle script, so the working tree stays untouched by anything except the diff I actually staged.
- Side benefit: cuts this step from several minutes (network-heavy, cloning multiple skill repos) down to a few seconds.

Found while working on #123 — repeatedly hit this: a clean, `git add`-ed commit touching `src/gateway/package.json` kept landing empty even after isolating and confirming the staged content itself was fine.

## Test plan

- [x] Reproduced the bug on `develop` HEAD: staged `src/gateway/package.json` + `src/gateway/README.md`, ran `src/githooks/_pre-commit.sh` directly — both files got dropped from the index (reverted to HEAD) after the hook completed, `git status` showed only `_pre-commit.sh` itself as clean/committed-equivalent.
- [x] Applied the fix, repeated the exact same repro: both files survived staged correctly, hook completed in ~10s (vs. several minutes before), no unrelated network calls or file rewrites.
- [x] Confirmed the actual commit (this PR's own commit) went through the real hook cleanly and landed with the expected single-file diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PU78ZMzqgdm2LucCqkxvFy)_