### PR TITLE
feat(devcontainer-features-larasets): ✨ enable Blade formatting in Pint lint script

### DIFF
--- a/src/larasets/README.md
+++ b/src/larasets/README.md
@@ -111,7 +111,7 @@ The following utilities are added to root composer:
 
 - `inst` - Install dependencies ignoring platform requirements.
 - `link` - Configure local repositories.
-- `lint` - Run Pint linter on staged files (--dirty by default).
+- `lint` - Run Pint linter on staged files (--dirty by default), including Blade template formatting (`--blade`: Alpine attributes, Livewire `wire:` bindings, Tailwind class sorting).
 - `lock` - Validate and update composer.lock with minimal changes.
 - `req` - Require a package with all dependencies ignoring platform requirements.
 - `reqdev` - Require a development package with all dependencies.

--- a/src/larasets/_package.require.json
+++ b/src/larasets/_package.require.json
@@ -2,7 +2,10 @@
     "dependencies": [],
     "devDependencies": [
         "smee-client",
-        "dotenv-cli"
+        "dotenv-cli",
+        "prettier",
+        "prettier-plugin-blade",
+        "prettier-plugin-tailwindcss"
     ],
     "globalDependencies": []
 }

--- a/src/larasets/_scripts.composer.json
+++ b/src/larasets/_scripts.composer.json
@@ -7,15 +7,11 @@
             "@php artisan ide-helper:generate --ansi",
             "@php artisan ide-helper:meta --ansi"
         ],
-        "inst": [
-            "composer install --ignore-platform-req=ext-*"
-        ],
+        "inst": ["composer install --ignore-platform-req=ext-*"],
         "link": [
             "composer config repositories.local '{\"type\": \"path\", \"url\": \"@additional_args\"}' --file composer.json"
         ],
-        "lint": [
-            "vendor/bin/pint --ansi --dirty"
-        ],
+        "lint": ["vendor/bin/pint --ansi --dirty --blade"],
         "lock": [
             "@base update --lock --no-scripts --no-interaction --no-progress --no-install",
             "composer validate --no-check-all --strict 2>&1 | grep -Eoi 'Required \\(in require-dev\\) package \\\"[^\\\"]+' | cut -d\"\\\"\" -f2 | xargs -r -I{} composer reqdev {}",
@@ -52,32 +48,12 @@
             "@php artisan optimize --ansi || true",
             "@php artisan filament:upgrade --ansi || true"
         ],
-        "pretest": [
-            "@php artisan optimize:clear --ansi || true"
-        ],
-        "req": [
-            "@base require",
-            "@helpers @no_additional_args"
-        ],
-        "reqdev": [
-            "@base require --dev",
-            "@helpers @no_additional_args"
-        ],
-        "rmv": [
-            "@base remove",
-            "@helpers @no_additional_args"
-        ],
-        "test": [
-            "@pretest",
-            "vendor/bin/pest"
-        ],
-        "test-coverage": [
-            "@pretest",
-            "vendor/bin/pest --coverage"
-        ],
-        "upg": [
-            "@base update",
-            "@helpers @no_additional_args"
-        ]
+        "pretest": ["@php artisan optimize:clear --ansi || true"],
+        "req": ["@base require", "@helpers @no_additional_args"],
+        "reqdev": ["@base require --dev", "@helpers @no_additional_args"],
+        "rmv": ["@base remove", "@helpers @no_additional_args"],
+        "test": ["@pretest", "vendor/bin/pest"],
+        "test-coverage": ["@pretest", "vendor/bin/pest --coverage"],
+        "upg": ["@base update", "@helpers @no_additional_args"]
     }
 }

--- a/src/larasets/stubs/.github/skills/feature-larasets/SKILL.md
+++ b/src/larasets/stubs/.github/skills/feature-larasets/SKILL.md
@@ -23,7 +23,7 @@ Use this feature for Laravel-focused developer experience in dev containers, inc
 - `smee` - Forward smee.io webhook deliveries to the local app.
 - `dep <...>` - Run Deployer with the SSH key loaded and secrets injected via `secret`.
 - `secret <...>` - Run any command with the SSH agent loaded and secrets injected: Doppler when available, else `.env`.
-- `composer lint` - Run Pint linting flow for project code.
+- `composer lint` - Run Pint linting flow for project code, including Blade template formatting.
 - `composer test` - Run Pest test suite.
 - `composer upg` - Update Composer dependencies with project defaults.
 

--- a/src/larasets/stubs/.github/workflows/fix-php.yml
+++ b/src/larasets/stubs/.github/workflows/fix-php.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           paths: ${{ github.event.inputs.paths }}
+          blade: 'true'
           fix: 'true'
 
       - name: Create or update PR

--- a/src/larasets/stubs/.github/workflows/validate-pr-php.yml
+++ b/src/larasets/stubs/.github/workflows/validate-pr-php.yml
@@ -33,6 +33,7 @@ jobs:
         uses: tomgrv/actions/check-laravel@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          pint-blade: 'true'
 
       - name: Run FilaCheck
         if: ${{ hashFiles('app/Filament/**') != '' }}


### PR DESCRIPTION
## Summary

- Laravel Pint 1.30 added Blade template formatting — Alpine attributes, Livewire `wire:` bindings, Flux components, and Tailwind class sorting for `.blade.php` files — behind a `--blade` flag, requiring `prettier` + `prettier-plugin-blade` + `prettier-plugin-tailwindcss` (see [Laravel News: Blade Formatting in Laravel Pint](https://laravel-news.com/blade-formatting-in-laravel-pint)).
- `larasets` already targets the TALL stack (`entexa.tall-stack`, `onecentlin.laravel-blade`, `pcbowers.alpine-intellisense` VS Code extensions), so this wires Blade formatting into the feature end-to-end:
  - `_scripts.composer.json`: `lint` now runs `vendor/bin/pint --ansi --dirty --blade`.
  - `_package.require.json`: adds `prettier`, `prettier-plugin-blade`, `prettier-plugin-tailwindcss` as npm dev dependencies so `configure-package.sh`/install-time provisioning pulls them in automatically.
  - `fix-php.yml` / `validate-pr-php.yml` stubs: pass `blade: 'true'` / `pint-blade: 'true'` to `run-pint` / `check-laravel` so CI lints and auto-fixes Blade files the same way, once [tomgrv/actions#67](https://github.com/tomgrv/actions/pull/67) (merged) and the `check-laravel` `pint-blade` follow-up land.
  - `README.md` / `feature-larasets` skill doc updated to mention Blade formatting.

## Test plan

- [x] `npx prettier --write`/`--check` run on all edited `.md`/`.json`/`.yml` files per repo convention.
- [ ] Run `npx tomgrv/devcontainer-features -- add larasets` (or `configure-feature larasets`) against a Laravel project and confirm `composer lint` formats `.blade.php` files without errors once the npm packages are installed.
- [ ] Confirm `fix-php.yml`/`validate-pr-php.yml` correctly report/fix Blade formatting once the `actions` repo's `run-pint`/`check-laravel` blade support is released.