### PR TITLE
fix(devcontainer-features-gateway): 🐛 restore SSL cert handling broken by curl-wrapper rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6286,7 +6286,7 @@
             "version": "7.18.0",
             "hasInstallScript": true,
             "bin": {
-                "gateway-curl": "stubs/.devcontainer/.gateway/_gateway-curl.sh"
+                "gateway-curl": "stubs/.devcontainer/.gateway/gateway-curl.sh"
             },
             "peerDependencies": {
                 "@tomgrv/devcontainer-features-common-utils": "*"

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -108,7 +108,7 @@ Once the host trusts the CA and the certificate sits in `.devcontainer/.gateway/
 
 Trusting the gateway root CA and diverting `curl` normally only happen at container-create time (`postCreateCommand`), which runs **after** the image is built — too late for any `RUN curl ...` in a custom Dockerfile, or for an earlier-ordered feature that fetches something over HTTPS during its own `install.sh`.
 
-The `.gateway/Dockerfile` stub closes that gap: it bakes both the root CA trust and the `gateway-curl` diversion into the very first layer of the image, before any feature runs. The mechanics it runs (`_install-certs-core.sh`, `_install-curl-wrapper-core.sh`, `_gateway-curl.sh`) live under `stubs/.devcontainer/.gateway/` and are the single source of truth: `configure-certs.sh`/`install-wrapper.sh` call the very same scripts from that same relative path at container-create time, rather than keeping a second copy at the feature root.
+The `.gateway/Dockerfile` stub closes that gap: it bakes both the root CA trust and the `gateway-curl` diversion into the very first layer of the image, before any feature runs. The mechanics it runs (`install-certs-core.sh`, `install-curl-wrapper-core.sh`, `gateway-curl.sh`) live under `stubs/.devcontainer/.gateway/` and are the single source of truth: `configure-certs.sh`/`install-wrapper.sh` call the very same scripts from that same relative path at container-create time, rather than keeping a second copy at the feature root.
 
 ## Modified repository structure
 

--- a/src/gateway/configure-certs.sh
+++ b/src/gateway/configure-certs.sh
@@ -51,7 +51,7 @@ if ! command -v update-ca-certificates >/dev/null 2>&1; then
     exit 0
 fi
 
-core="$(dirname "$0")/stubs/.devcontainer/.gateway/_install-certs-core.sh"
+core="$(dirname "$0")/stubs/.devcontainer/.gateway/install-certs-core.sh"
 if [ ! -f "$core" ]; then
     zz_log e "Core script not found at {U $core}"
     exit 1

--- a/src/gateway/install-wrapper.sh
+++ b/src/gateway/install-wrapper.sh
@@ -15,14 +15,14 @@ eval $(
 
 stub_dir="$target/stubs/.devcontainer/.gateway"
 
-wrapper="$stub_dir/_gateway-curl.sh"
+wrapper="$stub_dir/gateway-curl.sh"
 if [ ! -f "$wrapper" ]; then
     zz_log e "Wrapper not found at {U $wrapper}"
     exit 1
 fi
 chmod +x "$wrapper"
 
-core="$stub_dir/_install-curl-wrapper-core.sh"
+core="$stub_dir/install-curl-wrapper-core.sh"
 if [ ! -f "$core" ]; then
     zz_log e "Core script not found at {U $core}"
     exit 1

--- a/src/gateway/package.json
+++ b/src/gateway/package.json
@@ -3,7 +3,7 @@
     "description": "SSL Inspection Gateway handling",
     "version": "7.18.0",
     "bin": {
-        "gateway-curl": "stubs/.devcontainer/.gateway/_gateway-curl.sh"
+        "gateway-curl": "stubs/.devcontainer/.gateway/gateway-curl.sh"
     },
     "dependencies": {},
     "files": [

--- a/src/gateway/stubs/.devcontainer/.gateway/Dockerfile
+++ b/src/gateway/stubs/.devcontainer/.gateway/Dockerfile
@@ -28,9 +28,9 @@ RUN chmod +x /tmp/gateway/gateway-curl.sh \
 # itself sets these as containerEnv, but that only takes effect once the
 # container is created — too late for a `RUN npm install` here, or in any
 # feature layer that follows this Dockerfile during the image build.
-ENV COMPOSER_CA_FILE=/usr/local/share/ca-certificates/ca-certificates.crt \
-    CURL_CA_BUNDLE=/usr/local/share/ca-certificates/ca-certificates.crt \
-    GIT_SSL_CAINFO=/usr/local/share/ca-certificates/ca-certificates.crt \
-    NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/ca-certificates.crt \
-    REQUESTS_CA_BUNDLE=/usr/local/share/ca-certificates/ca-certificates.crt \
-    SSL_CERT_FILE=/usr/local/share/ca-certificates/ca-certificates.crt
+ENV COMPOSER_CA_FILE=/etc/ssl/certs/ca-certificates.crt \
+    CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
+    NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
+    SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt

--- a/src/gateway/stubs/.devcontainer/.gateway/install-certs-core.sh
+++ b/src/gateway/stubs/.devcontainer/.gateway/install-certs-core.sh
@@ -5,7 +5,7 @@
 # when/how/as-whom to invoke it. Runs unprivileged and privileged alike
 # (image build stage, postCreateCommand via sudo, ...).
 #
-# Usage: _install-certs-core.sh <certs_dir>
+# Usage: install-certs-core.sh <certs_dir>
 # Exit codes: 0 = nothing to do / up to date / installed, 1 = copy failed
 #
 # CERT_STORE_DIR overrides the trust store directory (default:

--- a/src/gateway/stubs/.devcontainer/.gateway/install-curl-wrapper-core.sh
+++ b/src/gateway/stubs/.devcontainer/.gateway/install-curl-wrapper-core.sh
@@ -6,8 +6,8 @@
 # host install, ...).
 #
 # Usage:
-#   _install-curl-wrapper-core.sh install <wrapper_src> <bindir>
-#   _install-curl-wrapper-core.sh divert  <bindir>
+#   install-curl-wrapper-core.sh install <wrapper_src> <bindir>
+#   install-curl-wrapper-core.sh divert  <bindir>
 #
 # 'install' copies <wrapper_src> to <bindir>/gateway-curl.
 # 'divert' points the system curl to <bindir>/gateway-curl, keeping the real

--- a/test/gateway/helpers.bash
+++ b/test/gateway/helpers.bash
@@ -6,10 +6,10 @@ GATEWAY_STUB_DIR="$GATEWAY_DIR/stubs/.devcontainer/.gateway"
 setup_gateway_path() {
     local file
     TEST_BIN=$(mktemp -d)
-    for file in "$GATEWAY_STUB_DIR"/_*.sh; do
+    for file in "$GATEWAY_STUB_DIR"/*.sh; do
         [ -f "$file" ] || continue
         chmod +x "$file"
-        ln -sf "$file" "$TEST_BIN/$(basename "$file" | sed 's/^_//; s/\.sh$//')"
+        ln -sf "$file" "$TEST_BIN/$(basename "$file" .sh)"
     done
     export PATH="$TEST_BIN:$PATH"
 }

--- a/test/gateway/test-curl-wrapper-core.bats
+++ b/test/gateway/test-curl-wrapper-core.bats
@@ -28,7 +28,7 @@ teardown() {
 }
 
 @test "install: copies wrapper as gateway-curl, executable" {
-    run install-curl-wrapper-core install "$GATEWAY_STUB_DIR/_gateway-curl.sh" "$BINDIR"
+    run install-curl-wrapper-core install "$GATEWAY_STUB_DIR/gateway-curl.sh" "$BINDIR"
     [ "$status" -eq 0 ]
     [ -x "$BINDIR/gateway-curl" ]
 }
@@ -39,7 +39,7 @@ teardown() {
 }
 
 @test "divert: curl symlinked to wrapper, real curl kept as .real" {
-    install-curl-wrapper-core install "$GATEWAY_STUB_DIR/_gateway-curl.sh" "$BINDIR"
+    install-curl-wrapper-core install "$GATEWAY_STUB_DIR/gateway-curl.sh" "$BINDIR"
     curl_bin="$FAKE_CURL_DIR/curl"
     run install-curl-wrapper-core divert "$BINDIR"
     [ "$status" -eq 0 ]
@@ -48,7 +48,7 @@ teardown() {
 }
 
 @test "divert: idempotent when already diverted" {
-    install-curl-wrapper-core install "$GATEWAY_STUB_DIR/_gateway-curl.sh" "$BINDIR"
+    install-curl-wrapper-core install "$GATEWAY_STUB_DIR/gateway-curl.sh" "$BINDIR"
     install-curl-wrapper-core divert "$BINDIR"
     run install-curl-wrapper-core divert "$BINDIR"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

- `36c782a` renamed `_gateway-curl.sh` → `gateway-curl.sh` (and the two `_install-*-core.sh` scripts) but left `install-wrapper.sh`, `configure-certs.sh`, and `package.json` pointing at the old underscore-prefixed filenames, so cert install / curl diversion silently failed at container-create time ("Core script not found").
- The same commit also swapped the CA bundle env vars (`CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `SSL_CERT_FILE`, `COMPOSER_CA_FILE`) from the real combined bundle at `/etc/ssl/certs/ca-certificates.crt` to `/usr/local/share/ca-certificates`, which is only a directory of individual per-cert files installed by `update-ca-certificates` — not a bundle file. Tools honoring those vars (curl, git, npm/node, pip, composer) would fail TLS verification.
- This matches the SSL failure (curl exit 77-class error) seen when installing an unrelated devcontainer feature through the gateway-diverted `curl`.

## Changes

- `src/gateway/install-wrapper.sh`, `src/gateway/configure-certs.sh`, `src/gateway/package.json`, `package-lock.json`, `src/gateway/README.md`: point at the renamed (non-underscore) stub filenames.
- `src/gateway/stubs/.devcontainer/.gateway/Dockerfile`: revert `ENV *_CA_*` vars back to `/etc/ssl/certs/ca-certificates.crt`.
- `install-certs-core.sh` / `install-curl-wrapper-core.sh`: fix stale filenames in usage comments.

## Test plan

- [x] `sh -n` syntax check on all touched shell scripts
- [x] Ran `install-certs-core.sh` and `install-curl-wrapper-core.sh install` standalone with the renamed paths — both exit 0, wrapper installed correctly
- [x] Verified `/etc/ssl/certs/ca-certificates.crt` is the real combined bundle vs. `/usr/local/share/ca-certificates/` being only individual `.crt` files
- [x] Reproduced `gateway-curl.sh` downloading a real binary tarball end-to-end — valid gzip output, exit 0
- [ ] Full devcontainer image build (not run in this sandbox)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EmYhPr3FuPhyr3cfYN8Vps)_